### PR TITLE
Correct the light level for blind tilt

### DIFF
--- a/switchbot/adv_parsers/blind_tilt.py
+++ b/switchbot/adv_parsers/blind_tilt.py
@@ -14,7 +14,7 @@ def process_woblindtilt(
 
     _tilt = max(min(device_data[2] & 0b01111111, 100), 0)
     _in_motion = bool(device_data[2] & 0b10000000)
-    _light_level = (device_data[1] >> 4) & 0b00001111
+    _light_level = (device_data[3] >> 4) & 0b00001111
     _calibrated = bool(device_data[1] & 0b00000001)
 
     return {

--- a/tests/test_adv_parser.py
+++ b/tests/test_adv_parser.py
@@ -3008,16 +3008,14 @@ def test_blind_tilt_active() -> None:
     ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
     adv_data = generate_advertisement_data(
         manufacturer_data={2409: b"\xfc(\\6l\x7f\x0b'\x00\xa1\x84"},
-        service_data={
-            "0000fd3d-0000-1000-8000-00805f9b34fb": b'x\x00H'
-        },
+        service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": b"x\x00H"},
         rssi=-97,
     )
     result = parse_advertisement_data(ble_device, adv_data)
     assert result == SwitchBotAdvertisement(
         address="aa:bb:cc:dd:ee:ff",
         data={
-            "rawAdvData": b'x\x00H',
+            "rawAdvData": b"x\x00H",
             "data": {
                 "sequence_number": 11,
                 "battery": 72,
@@ -3025,7 +3023,6 @@ def test_blind_tilt_active() -> None:
                 "inMotion": False,
                 "calibration": True,
                 "lightLevel": 10,
-
             },
             "isEncrypted": False,
             "model": "x",
@@ -3036,6 +3033,7 @@ def test_blind_tilt_active() -> None:
         rssi=-97,
         active=True,
     )
+
 
 def test_blind_tilt_passive() -> None:
     """Test parsing blind tilt with passive data."""
@@ -3056,7 +3054,6 @@ def test_blind_tilt_passive() -> None:
                 "inMotion": False,
                 "calibration": True,
                 "lightLevel": 10,
-
             },
             "isEncrypted": False,
             "model": "x",
@@ -3074,16 +3071,14 @@ def test_blind_tilt_with_empty_data() -> None:
     ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
     adv_data = generate_advertisement_data(
         manufacturer_data={2409: None},
-        service_data={
-            "0000fd3d-0000-1000-8000-00805f9b34fb": b'x\x00H'
-        },
+        service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": b"x\x00H"},
         rssi=-97,
     )
     result = parse_advertisement_data(ble_device, adv_data)
     assert result == SwitchBotAdvertisement(
         address="aa:bb:cc:dd:ee:ff",
         data={
-            "rawAdvData": b'x\x00H',
+            "rawAdvData": b"x\x00H",
             "data": {},
             "isEncrypted": False,
             "model": "x",

--- a/tests/test_adv_parser.py
+++ b/tests/test_adv_parser.py
@@ -3001,3 +3001,94 @@ def test_lock_with_empty_data(test_case: AdvTestCase) -> None:
         rssi=-97,
         active=True,
     )
+
+
+def test_blind_tilt_active() -> None:
+    """Test parsing blind tilt with active data."""
+    ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
+    adv_data = generate_advertisement_data(
+        manufacturer_data={2409: b"\xfc(\\6l\x7f\x0b'\x00\xa1\x84"},
+        service_data={
+            "0000fd3d-0000-1000-8000-00805f9b34fb": b'x\x00H'
+        },
+        rssi=-97,
+    )
+    result = parse_advertisement_data(ble_device, adv_data)
+    assert result == SwitchBotAdvertisement(
+        address="aa:bb:cc:dd:ee:ff",
+        data={
+            "rawAdvData": b'x\x00H',
+            "data": {
+                "sequence_number": 11,
+                "battery": 72,
+                "tilt": 0,
+                "inMotion": False,
+                "calibration": True,
+                "lightLevel": 10,
+
+            },
+            "isEncrypted": False,
+            "model": "x",
+            "modelFriendlyName": "Blind Tilt",
+            "modelName": SwitchbotModel.BLIND_TILT,
+        },
+        device=ble_device,
+        rssi=-97,
+        active=True,
+    )
+
+def test_blind_tilt_passive() -> None:
+    """Test parsing blind tilt with passive data."""
+    ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
+    adv_data = generate_advertisement_data(
+        manufacturer_data={2409: b"\xfc(\\6l\x7f\x0b'\x00\xa1\x84"},
+        rssi=-97,
+    )
+    result = parse_advertisement_data(ble_device, adv_data, SwitchbotModel.BLIND_TILT)
+    assert result == SwitchBotAdvertisement(
+        address="aa:bb:cc:dd:ee:ff",
+        data={
+            "rawAdvData": None,
+            "data": {
+                "sequence_number": 11,
+                "battery": None,
+                "tilt": 0,
+                "inMotion": False,
+                "calibration": True,
+                "lightLevel": 10,
+
+            },
+            "isEncrypted": False,
+            "model": "x",
+            "modelFriendlyName": "Blind Tilt",
+            "modelName": SwitchbotModel.BLIND_TILT,
+        },
+        device=ble_device,
+        rssi=-97,
+        active=False,
+    )
+
+
+def test_blind_tilt_with_empty_data() -> None:
+    """Test parsing blind tilt with empty data."""
+    ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
+    adv_data = generate_advertisement_data(
+        manufacturer_data={2409: None},
+        service_data={
+            "0000fd3d-0000-1000-8000-00805f9b34fb": b'x\x00H'
+        },
+        rssi=-97,
+    )
+    result = parse_advertisement_data(ble_device, adv_data)
+    assert result == SwitchBotAdvertisement(
+        address="aa:bb:cc:dd:ee:ff",
+        data={
+            "rawAdvData": b'x\x00H',
+            "data": {},
+            "isEncrypted": False,
+            "model": "x",
+        },
+        device=ble_device,
+        rssi=-97,
+        active=True,
+    )


### PR DESCRIPTION
Correct the adv parser for blind tilt light level, and it relates to the case https://github.com/home-assistant/core/issues/94742
Note: When the light intensity changes, the light level will not be updated immediately. It may take at least 20 minutes to confirm that the current light intensity has stabilized and then update the light level.