### PR TITLE
Add support for relay switch series

### DIFF
--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -32,7 +32,7 @@ from .devices.humidifier import SwitchbotHumidifier
 from .devices.light_strip import SwitchbotLightStrip
 from .devices.lock import SwitchbotLock
 from .devices.plug import SwitchbotPlugMini
-from .devices.relay_switch import SwitchbotRelaySwitch
+from .devices.relay_switch import SwitchbotRelaySwitch, SwitchbotRelaySwitch2PM
 from .devices.roller_shade import SwitchbotRollerShade
 from .devices.vacuum import SwitchbotVacuum
 from .discovery import GetSwitchbotDevices
@@ -68,6 +68,7 @@ __all__ = [
     "SwitchbotPlugMini",
     "SwitchbotPlugMini",
     "SwitchbotRelaySwitch",
+    "SwitchbotRelaySwitch2PM",
     "SwitchbotRollerShade",
     "SwitchbotSupportedType",
     "SwitchbotSupportedType",

--- a/switchbot/adv_parser.py
+++ b/switchbot/adv_parser.py
@@ -31,7 +31,6 @@ from .adv_parsers.motion import process_wopresence
 from .adv_parsers.plug import process_woplugmini
 from .adv_parsers.relay_switch import (
     process_garage_door_opener,
-    process_relay_switch_1pm,
     process_relay_switch_2pm,
     process_relay_switch_common_data,
 )
@@ -209,7 +208,7 @@ SUPPORTED_TYPES: dict[str | bytes, SwitchbotSupportedType] = {
     "<": {
         "modelName": SwitchbotModel.RELAY_SWITCH_1PM,
         "modelFriendlyName": "Relay Switch 1PM",
-        "func": process_relay_switch_1pm,
+        "func": process_relay_switch_common_data,
         "manufacturer_id": 2409,
     },
     ";": {

--- a/switchbot/adv_parser.py
+++ b/switchbot/adv_parser.py
@@ -30,8 +30,10 @@ from .adv_parsers.meter import process_wosensorth, process_wosensorth_c
 from .adv_parsers.motion import process_wopresence
 from .adv_parsers.plug import process_woplugmini
 from .adv_parsers.relay_switch import (
-    process_worelay_switch_1,
-    process_worelay_switch_1pm,
+    process_garage_door_opener,
+    process_relay_switch_1pm,
+    process_relay_switch_2pm,
+    process_relay_switch_common_data,
 )
 from .adv_parsers.remote import process_woremote
 from .adv_parsers.roller_shade import process_worollershade
@@ -207,13 +209,13 @@ SUPPORTED_TYPES: dict[str | bytes, SwitchbotSupportedType] = {
     "<": {
         "modelName": SwitchbotModel.RELAY_SWITCH_1PM,
         "modelFriendlyName": "Relay Switch 1PM",
-        "func": process_worelay_switch_1pm,
+        "func": process_relay_switch_1pm,
         "manufacturer_id": 2409,
     },
     ";": {
         "modelName": SwitchbotModel.RELAY_SWITCH_1,
         "modelFriendlyName": "Relay Switch 1",
-        "func": process_worelay_switch_1,
+        "func": process_relay_switch_common_data,
         "manufacturer_id": 2409,
     },
     "b": {
@@ -312,6 +314,19 @@ SUPPORTED_TYPES: dict[str | bytes, SwitchbotSupportedType] = {
         "func": process_lock2,
         "manufacturer_id": 2409,
     },
+    ">": {
+        "modelName": SwitchbotModel.GARAGE_DOOR_OPENER,
+        "modelFriendlyName": "Garage Door Opener",
+        "func": process_garage_door_opener,
+        "manufacturer_id": 2409,
+    },
+    "=": {
+        "modelName": SwitchbotModel.RELAY_SWITCH_2PM,
+        "modelFriendlyName": "Relay Switch 2PM",
+        "func": process_relay_switch_2pm,
+        "manufacturer_id": 2409,
+    }
+
 }
 
 _SWITCHBOT_MODEL_TO_CHAR = {

--- a/switchbot/adv_parsers/relay_switch.py
+++ b/switchbot/adv_parsers/relay_switch.py
@@ -28,8 +28,6 @@ def process_relay_switch_1pm(data: bytes | None, mfr_data: bytes | None) -> dict
         return {}
     common_data = process_relay_switch_common_data(data, mfr_data)
     common_data["power"] = parse_power_data(mfr_data, 10, 12)
-    common_data["voltage"] = 0
-    common_data["current"] = 0
     return common_data
 
 
@@ -51,16 +49,12 @@ def process_relay_switch_2pm(data: bytes | None, mfr_data: bytes | None) -> dict
         1: {
             **process_relay_switch_common_data(data, mfr_data),
             "power": parse_power_data(mfr_data, 10, 12),
-            "voltage": 0,
-            "current": 0,
         },
         2: {
             "switchMode": True,  # for compatibility, useless
             "sequence_number": mfr_data[6],
             "isOn": bool(mfr_data[7] & 0b01000000),
             "power": parse_power_data(mfr_data, 12, 14),
-            "voltage": 0,
-            "current": 0,
         },
     }
 

--- a/switchbot/adv_parsers/relay_switch.py
+++ b/switchbot/adv_parsers/relay_switch.py
@@ -2,27 +2,17 @@
 
 from __future__ import annotations
 
-
-def process_worelay_switch_1pm(
-    data: bytes | None, mfr_data: bytes | None
-) -> dict[str, bool | int]:
-    """Process WoStrip services data."""
-    if mfr_data is None:
-        return {}
-    return {
-        "switchMode": True,  # for compatibility, useless
-        "sequence_number": mfr_data[6],
-        "isOn": bool(mfr_data[7] & 0b10000000),
-        "power": ((mfr_data[10] << 8) + mfr_data[11]) / 10,
-        "voltage": 0,
-        "current": 0,
-    }
+import struct
+from typing import Any
 
 
-def process_worelay_switch_1(
-    data: bytes | None, mfr_data: bytes | None
-) -> dict[str, bool | int]:
-    """Process WoStrip services data."""
+def parse_power_data(mfr_data: bytes, start: int, end: int) -> int:
+    """Helper to parse power data from manufacturer data."""
+    return struct.unpack(">H", mfr_data[start:end])[0] / 10.0
+
+
+def process_relay_switch_common_data(data: bytes | None, mfr_data: bytes | None) -> dict[str, Any]:
+    """Process relay switch common data."""
     if mfr_data is None:
         return {}
     return {
@@ -30,3 +20,50 @@ def process_worelay_switch_1(
         "sequence_number": mfr_data[6],
         "isOn": bool(mfr_data[7] & 0b10000000),
     }
+
+
+def process_relay_switch_1pm(data: bytes | None, mfr_data: bytes | None) -> dict[str, Any]:
+    """Process Relay Switch 1PM services data."""
+    if mfr_data is None:
+        return {}
+    common_data = process_relay_switch_common_data(data, mfr_data)
+    common_data["power"] = parse_power_data(mfr_data, 10, 12)
+    common_data["voltage"] = 0
+    common_data["current"] = 0
+    return common_data
+
+
+def process_garage_door_opener(data: bytes | None, mfr_data: bytes | None) -> dict[str, Any]:
+    """Process garage door opener services data."""
+    if mfr_data is None:
+        return {}
+    common_data = process_relay_switch_common_data(data, mfr_data)
+    common_data["door_open"] = not bool(mfr_data[7] & 0b00100000)
+    return common_data
+
+
+def process_relay_switch_2pm(data: bytes | None, mfr_data: bytes | None) -> dict[int, dict[str, Any]]:
+    """Process Relay Switch 2PM services data."""
+    if mfr_data is None:
+        return {}
+
+    return {
+        1: {
+            **process_relay_switch_common_data(data, mfr_data),
+            "power": parse_power_data(mfr_data, 10, 12),
+            "voltage": 0,
+            "current": 0,
+        },
+        2: {
+            "switchMode": True,  # for compatibility, useless
+            "sequence_number": mfr_data[6],
+            "isOn": bool(mfr_data[7] & 0b01000000),
+            "power": parse_power_data(mfr_data, 12, 14),
+            "voltage": 0,
+            "current": 0,
+        },
+    }
+
+
+
+

--- a/switchbot/adv_parsers/relay_switch.py
+++ b/switchbot/adv_parsers/relay_switch.py
@@ -2,17 +2,11 @@
 
 from __future__ import annotations
 
-import struct
 from typing import Any
 
 
-def parse_power_data(mfr_data: bytes, start: int, end: int) -> int:
-    """Helper to parse power data from manufacturer data."""
-    return struct.unpack(">H", mfr_data[start:end])[0] / 10.0
-
-
 def process_relay_switch_common_data(data: bytes | None, mfr_data: bytes | None) -> dict[str, Any]:
-    """Process relay switch common data."""
+    """Process relay switch 1 and 1PM common data."""
     if mfr_data is None:
         return {}
     return {
@@ -20,16 +14,6 @@ def process_relay_switch_common_data(data: bytes | None, mfr_data: bytes | None)
         "sequence_number": mfr_data[6],
         "isOn": bool(mfr_data[7] & 0b10000000),
     }
-
-
-def process_relay_switch_1pm(data: bytes | None, mfr_data: bytes | None) -> dict[str, Any]:
-    """Process Relay Switch 1PM services data."""
-    if mfr_data is None:
-        return {}
-    common_data = process_relay_switch_common_data(data, mfr_data)
-    common_data["power"] = parse_power_data(mfr_data, 10, 12)
-    return common_data
-
 
 def process_garage_door_opener(data: bytes | None, mfr_data: bytes | None) -> dict[str, Any]:
     """Process garage door opener services data."""
@@ -39,7 +23,6 @@ def process_garage_door_opener(data: bytes | None, mfr_data: bytes | None) -> di
     common_data["door_open"] = not bool(mfr_data[7] & 0b00100000)
     return common_data
 
-
 def process_relay_switch_2pm(data: bytes | None, mfr_data: bytes | None) -> dict[int, dict[str, Any]]:
     """Process Relay Switch 2PM services data."""
     if mfr_data is None:
@@ -48,13 +31,11 @@ def process_relay_switch_2pm(data: bytes | None, mfr_data: bytes | None) -> dict
     return {
         1: {
             **process_relay_switch_common_data(data, mfr_data),
-            "power": parse_power_data(mfr_data, 10, 12),
         },
         2: {
             "switchMode": True,  # for compatibility, useless
             "sequence_number": mfr_data[6],
             "isOn": bool(mfr_data[7] & 0b01000000),
-            "power": parse_power_data(mfr_data, 12, 14),
         },
     }
 

--- a/switchbot/const/__init__.py
+++ b/switchbot/const/__init__.py
@@ -78,6 +78,8 @@ class SwitchbotModel(StrEnum):
     HUB3 = "Hub3"
     LOCK_ULTRA = "Lock Ultra"
     LOCK_LITE = "Lock Lite"
+    GARAGE_DOOR_OPENER = "Garage Door Opener"
+    RELAY_SWITCH_2PM = "Relay Switch 2PM"
 
 
 __all__ = [

--- a/switchbot/const/__init__.py
+++ b/switchbot/const/__init__.py
@@ -62,7 +62,7 @@ class SwitchbotModel(StrEnum):
     LEAK = "Leak Detector"
     KEYPAD = "WoKeypad"
     RELAY_SWITCH_1PM = "Relay Switch 1PM"
-    RELAY_SWITCH_1 = "Relay Switch 1 Plus"
+    RELAY_SWITCH_1 = "Relay Switch 1"
     REMOTE = "WoRemote"
     EVAPORATIVE_HUMIDIFIER = "Evaporative Humidifier"
     ROLLER_SHADE = "Roller Shade"

--- a/switchbot/const/__init__.py
+++ b/switchbot/const/__init__.py
@@ -62,7 +62,7 @@ class SwitchbotModel(StrEnum):
     LEAK = "Leak Detector"
     KEYPAD = "WoKeypad"
     RELAY_SWITCH_1PM = "Relay Switch 1PM"
-    RELAY_SWITCH_1 = "Relay Switch 1"
+    RELAY_SWITCH_1 = "Relay Switch 1 Plus"
     REMOTE = "WoRemote"
     EVAPORATIVE_HUMIDIFIER = "Evaporative Humidifier"
     ROLLER_SHADE = "Roller Shade"

--- a/switchbot/devices/relay_switch.py
+++ b/switchbot/devices/relay_switch.py
@@ -95,8 +95,8 @@ class SwitchbotRelaySwitch(SwitchbotSequenceDevice, SwitchbotEncryptedDevice):
     def _parse_user_data(self, raw_data: bytes) -> dict[str, Any]:
         """Parse user-specific data from raw bytes."""
         return {
-            "Electricity": round(int.from_bytes(raw_data[1:4], "big") / 60000, 2),
-            "Electricity Usage Yesterday": round(int.from_bytes(raw_data[4:7], "big") / 60000, 2),
+            "electricity": round(int.from_bytes(raw_data[1:4], "big") / 60000, 2),
+            "electricity usage yesterday": round(int.from_bytes(raw_data[4:7], "big") / 60000, 2),
             "use_time": round(int.from_bytes(raw_data[7:9], "big") / 60, 2),
             "voltage": int.from_bytes(raw_data[9:11], "big") / 10.0,
             "current": int.from_bytes(raw_data[11:13], "big"),

--- a/switchbot/devices/relay_switch.py
+++ b/switchbot/devices/relay_switch.py
@@ -5,8 +5,11 @@ from typing import Any
 from bleak.backends.device import BLEDevice
 
 from ..const import SwitchbotModel
-from ..models import SwitchBotAdvertisement
-from .device import SwitchbotEncryptedDevice
+from .device import (
+    SwitchbotEncryptedDevice,
+    SwitchbotSequenceDevice,
+    update_after_operation,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -15,11 +18,39 @@ COMMAND_TURN_OFF = f"{COMMAND_HEADER}0f70010000"
 COMMAND_TURN_ON = f"{COMMAND_HEADER}0f70010100"
 COMMAND_TOGGLE = f"{COMMAND_HEADER}0f70010200"
 COMMAND_GET_VOLTAGE_AND_CURRENT = f"{COMMAND_HEADER}0f7106000000"
-COMMAND_GET_SWITCH_STATE = f"{COMMAND_HEADER}0f7101000000"
-PASSIVE_POLL_INTERVAL = 10 * 60
+
+COMMAND_GET_BASIC_INFO = f"{COMMAND_HEADER}0f7181"
+COMMAND_GET_CHANNEL1_INFO = f"{COMMAND_HEADER}0f710600{{}}{{}}"
+COMMAND_GET_CHANNEL2_INFO = f"{COMMAND_HEADER}0f710601{{}}{{}}"
 
 
-class SwitchbotRelaySwitch(SwitchbotEncryptedDevice):
+MULTI_CHANNEL_COMMANDS_TURN_ON = {
+    SwitchbotModel.RELAY_SWITCH_2PM: {
+        1: "570f70010d00",
+        2: "570f70010700",
+    }
+}
+MULTI_CHANNEL_COMMANDS_TURN_OFF = {
+    SwitchbotModel.RELAY_SWITCH_2PM: {
+        1: "570f70010c00",
+        2: "570f70010300",
+    }
+}
+MULTI_CHANNEL_COMMANDS_TOGGLE = {
+    SwitchbotModel.RELAY_SWITCH_2PM: {
+        1: "570f70010e00",
+        2: "570f70010b00",
+    }
+}
+MULTI_CHANNEL_COMMANDS_GET_VOLTAGE_AND_CURRENT = {
+    SwitchbotModel.RELAY_SWITCH_2PM: {
+        1: COMMAND_GET_CHANNEL1_INFO,
+        2: COMMAND_GET_CHANNEL2_INFO,
+    }
+}
+
+
+class SwitchbotRelaySwitch(SwitchbotSequenceDevice, SwitchbotEncryptedDevice):
     """Representation of a Switchbot relay switch 1pm."""
 
     def __init__(
@@ -31,7 +62,6 @@ class SwitchbotRelaySwitch(SwitchbotEncryptedDevice):
         model: SwitchbotModel = SwitchbotModel.RELAY_SWITCH_1PM,
         **kwargs: Any,
     ) -> None:
-        self._force_next_update = False
         super().__init__(device, key_id, encryption_key, model, interface, **kwargs)
 
     @classmethod
@@ -47,85 +77,64 @@ class SwitchbotRelaySwitch(SwitchbotEncryptedDevice):
             device, key_id, encryption_key, model, **kwargs
         )
 
-    def update_from_advertisement(self, advertisement: SwitchBotAdvertisement) -> None:
-        """Update device data from advertisement."""
-        # Obtain voltage and current through command.
-        adv_data = advertisement.data["data"]
-        if previous_voltage := self._get_adv_value("voltage"):
-            adv_data["voltage"] = previous_voltage
-        if previous_current := self._get_adv_value("current"):
-            adv_data["current"] = previous_current
-        current_state = self._get_adv_value("sequence_number")
-        super().update_from_advertisement(advertisement)
-        new_state = self._get_adv_value("sequence_number")
-        _LOGGER.debug(
-            "%s: update advertisement: %s (seq before: %s) (seq after: %s)",
-            self.name,
-            advertisement,
-            current_state,
-            new_state,
-        )
-        if current_state != new_state:
-            self._force_next_update = True
+    def get_current_time_and_start_time(self) -> int:
+        """Get current time in seconds since epoch."""
+        current_time = int(time.time())
+        current_time_hex = f"{current_time:08x}"
+        current_day_start_time = int(current_time / 86400) * 86400
+        current_day_start_time_hex = f"{current_day_start_time:08x}"
 
-    async def update(self, interface: int | None = None) -> None:
-        """Update state of device."""
-        if info := await self.get_voltage_and_current():
-            self._last_full_update = time.monotonic()
-            self._update_parsed_data(info)
-            self._fire_callbacks()
-
-    async def get_voltage_and_current(self) -> dict[str, Any] | None:
-        """Get voltage and current because advtisement don't have these"""
-        result = await self._send_command(COMMAND_GET_VOLTAGE_AND_CURRENT)
-        ok = self._check_command_result(result, 0, {1})
-        if ok:
-            return {
-                "voltage": ((result[9] << 8) + result[10]) / 10,
-                "current": (result[11] << 8) + result[12],
-            }
-        return None
+        return current_time_hex, current_day_start_time_hex
 
     async def get_basic_info(self) -> dict[str, Any] | None:
-        """Get the current state of the switch."""
-        result = await self._send_command(COMMAND_GET_SWITCH_STATE)
-        if self._check_command_result(result, 0, {1}):
-            return {
-                "is_on": result[1] & 0x01 != 0,
-            }
-        return None
+        """Get device basic settings."""
+        current_time_hex, current_day_start_time_hex = self.get_current_time_and_start_time()
 
-    def poll_needed(self, seconds_since_last_poll: float | None) -> bool:
-        """Return if device needs polling."""
-        if self._force_next_update:
-            self._force_next_update = False
-            return True
-        if (
-            seconds_since_last_poll is not None
-            and seconds_since_last_poll < PASSIVE_POLL_INTERVAL
-        ):
-            return False
-        time_since_last_full_update = time.monotonic() - self._last_full_update
-        return not time_since_last_full_update < PASSIVE_POLL_INTERVAL
+        if not (_data := await self._get_basic_info(COMMAND_GET_BASIC_INFO)):
+            return None
+        if not (_channel1_data := await self._get_basic_info(COMMAND_GET_CHANNEL1_INFO.format(current_time_hex, current_day_start_time_hex))):
+            return None
 
+        common_data = {
+            "isOn": bool(_data[2] & 0b10000000),
+            "firmware": _data[16] / 10.0,
+            "use_time": int.from_bytes(_channel1_data[7:9], "big"),
+
+        }
+
+        user_data = {
+            "Electricity Usage Today": int.from_bytes(_channel1_data[1:4], "big"),
+            "Electricity Usage Yesterday": int.from_bytes(_channel1_data[4:7], "big"),
+            "voltage": int.from_bytes(_channel1_data[9:11], "big") / 10.0,
+            "current": int.from_bytes(_channel1_data[11:13], "big"),
+            "power": int.from_bytes(_channel1_data[13:15], "big") / 10.0,
+        }
+
+        garage_door_opener_data = {
+            "door_open": not bool(_data[7] & 0b00100000),
+        }
+
+        _LOGGER.debug("common_data: %s, garage_door_opener_data: %s", common_data, garage_door_opener_data)
+
+        if self._model == SwitchbotModel.RELAY_SWITCH_1:
+            return common_data
+        if self._model == SwitchbotModel.GARAGE_DOOR_OPENER:
+            return common_data | garage_door_opener_data
+        return common_data | user_data
+
+    @update_after_operation
     async def turn_on(self) -> bool:
         """Turn device on."""
         result = await self._send_command(COMMAND_TURN_ON)
-        ok = self._check_command_result(result, 0, {1})
-        if ok:
-            self._override_state({"isOn": True})
-            self._fire_callbacks()
-        return ok
+        return self._check_command_result(result, 0, {1})
 
+    @update_after_operation
     async def turn_off(self) -> bool:
         """Turn device off."""
         result = await self._send_command(COMMAND_TURN_OFF)
-        ok = self._check_command_result(result, 0, {1})
-        if ok:
-            self._override_state({"isOn": False})
-            self._fire_callbacks()
-        return ok
+        return self._check_command_result(result, 0, {1})
 
+    @update_after_operation
     async def async_toggle(self, **kwargs) -> bool:
         """Toggle device."""
         result = await self._send_command(COMMAND_TOGGLE)
@@ -134,3 +143,81 @@ class SwitchbotRelaySwitch(SwitchbotEncryptedDevice):
     def is_on(self) -> bool | None:
         """Return switch state from cache."""
         return self._get_adv_value("isOn")
+
+
+class SwitchbotRelaySwitch2PM(SwitchbotRelaySwitch):
+    """Representation of a Switchbot relay switch 2pm."""
+
+    def __init__(
+        self,
+        device: BLEDevice,
+        key_id: str,
+        encryption_key: str,
+        interface: int = 0,
+        model: SwitchbotModel = SwitchbotModel.RELAY_SWITCH_2PM,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(device, key_id, encryption_key, interface, model, **kwargs)
+        self._channel = 2
+
+    @property
+    def channel(self) -> int:
+        return self._channel
+
+    def get_parsed_data(self, channel: int | None = None) -> dict[str, Any]:
+        """Return parsed device data, optionally for a specific channel."""
+        data = self.data.get("data") or {}
+        return data.get(channel, {})
+
+    async def get_basic_info(self):
+        current_time_hex, current_day_start_time_hex = self.get_current_time_and_start_time()
+        if not (common_data := await super().get_basic_info()):
+            return None
+        if not (
+                _channel2_data := await self._get_basic_info(COMMAND_GET_CHANNEL2_INFO.format(current_time_hex, current_day_start_time_hex))
+            ):
+            return None
+
+
+        result = {
+            1: common_data,
+            2: {
+                "isOn": bool(_channel2_data[2] & 0b01000000),
+                "Electricity Usage Today": int.from_bytes(_channel2_data[1:4], "big"),
+                "Electricity Usage Yesterday": int.from_bytes(_channel2_data[4:7], "big"),
+                "use_time": int.from_bytes(_channel2_data[7:9], "big"),
+                "voltage": int.from_bytes(_channel2_data[9:11], "big") / 10.0,
+                "current": int.from_bytes(_channel2_data[11:13], "big"),
+                "power": int.from_bytes(_channel2_data[13:15], "big") / 10.0,
+            }
+        }
+
+        _LOGGER.debug("Multi channel basic info: %s", result)
+
+        return result
+
+    @update_after_operation
+    async def turn_on(self, channel: int) -> bool:
+        """Turn device on."""
+        result = await self._send_command(MULTI_CHANNEL_COMMANDS_TURN_ON[self._model][channel])
+        return self._check_command_result(result, 0, {1})
+
+    @update_after_operation
+    async def turn_off(self, channel: int) -> bool:
+        """Turn device off."""
+        result = await self._send_command(MULTI_CHANNEL_COMMANDS_TURN_OFF[self._model][channel])
+        return self._check_command_result(result, 0, {1})
+
+    @update_after_operation
+    async def async_toggle(self, channel: int) -> bool:
+        """Toggle device."""
+        result = await self._send_command(MULTI_CHANNEL_COMMANDS_TOGGLE[self._model][channel])
+        return self._check_command_result(result, 0, {1})
+
+    def is_on(self, channel: int) -> bool | None:
+        """Return switch state from cache."""
+        return self._get_adv_value("isOn", channel)
+
+    def switch_mode(self, channel: int) -> bool | None:
+        """Return true or false from cache."""
+        return self._get_adv_value("switchMode", channel)

--- a/switchbot/devices/relay_switch.py
+++ b/switchbot/devices/relay_switch.py
@@ -95,8 +95,8 @@ class SwitchbotRelaySwitch(SwitchbotSequenceDevice, SwitchbotEncryptedDevice):
     def _parse_user_data(self, raw_data: bytes) -> dict[str, Any]:
         """Parse user-specific data from raw bytes."""
         return {
-            "electricity": round(int.from_bytes(raw_data[1:4], "big") / 60000, 2),
-            "electricity usage yesterday": round(int.from_bytes(raw_data[4:7], "big") / 60000, 2),
+            "energy": round(int.from_bytes(raw_data[1:4], "big") / 60000, 2),
+            "energy usage yesterday": round(int.from_bytes(raw_data[4:7], "big") / 60000, 2),
             "use_time": round(int.from_bytes(raw_data[7:9], "big") / 60, 2),
             "voltage": int.from_bytes(raw_data[9:11], "big") / 10.0,
             "current": int.from_bytes(raw_data[11:13], "big"),
@@ -116,12 +116,14 @@ class SwitchbotRelaySwitch(SwitchbotSequenceDevice, SwitchbotEncryptedDevice):
                 adv_data["voltage"] = self._get_adv_value("voltage") or 0
                 adv_data["current"] = self._get_adv_value("current") or 0
                 adv_data["power"] = self._get_adv_value("power") or 0
+                adv_data["energy"] = self._get_adv_value("energy") or 0
             else:
                 for i in range(1, channel + 1):
                     adv_data[i] = adv_data.get(i, {})
                     adv_data[i]["voltage"] = self._get_adv_value("voltage", i) or 0
                     adv_data[i]["current"] = self._get_adv_value("current", i) or 0
                     adv_data[i]["power"] = self._get_adv_value("power", i) or 0
+                    adv_data[i]["energy"] = self._get_adv_value("energy", i) or 0
         super().update_from_advertisement(advertisement)
 
 
@@ -149,7 +151,7 @@ class SwitchbotRelaySwitch(SwitchbotSequenceDevice, SwitchbotEncryptedDevice):
         user_data = self._parse_user_data(_channel1_data)
 
         if self._model in (SwitchbotModel.RELAY_SWITCH_1, SwitchbotModel.GARAGE_DOOR_OPENER):
-            for key in ["voltage", "current", "power"]:
+            for key in ["voltage", "current", "power", "energy"]:
                 user_data.pop(key, None)
 
         if not common_data["isOn"]:

--- a/tests/test_adv_parser.py
+++ b/tests/test_adv_parser.py
@@ -3033,13 +3033,11 @@ def test_blind_tilt_with_empty_data() -> None:
             {
                 1: {
                     'isOn': True,
-                    'power': 0.0,
                     'sequence_number': 138,
                     'switchMode': True,
                 },
                 2: {
                     'isOn': True,
-                    'power': 7.0,
                     'sequence_number': 138,
                     'switchMode': True,
                 },
@@ -3065,7 +3063,6 @@ def test_blind_tilt_with_empty_data() -> None:
             b"<\x00\x00\x00",
             {
                 'isOn': True,
-                'power': 4.9,
                 'sequence_number': 71,
                 'switchMode': True,
             },
@@ -3123,13 +3120,11 @@ def test_adv_active(test_case: AdvTestCase) -> None:
             {
                 1: {
                     'isOn': True,
-                    'power': 0.0,
                     'sequence_number': 138,
                     'switchMode': True,
                 },
                 2: {
                     'isOn': True,
-                    'power': 7.0,
                     'sequence_number': 138,
                     'switchMode': True,
                 },
@@ -3155,7 +3150,6 @@ def test_adv_active(test_case: AdvTestCase) -> None:
             b"<\x00\x00\x00",
             {
                 'isOn': True,
-                'power': 4.9,
                 'sequence_number': 71,
                 'switchMode': True,
             },

--- a/tests/test_adv_parser.py
+++ b/tests/test_adv_parser.py
@@ -1437,71 +1437,6 @@ def test_parse_advertisement_data_keypad():
     )
 
 
-def test_parse_advertisement_data_relay_switch_1pm():
-    """Test parse_advertisement_data for the keypad."""
-    ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
-    adv_data = generate_advertisement_data(
-        manufacturer_data={2409: b"$X|\x0866G\x81\x00\x00\x001\x00\x00\x00\x00"},
-        service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": b"<\x00\x00\x00"},
-        rssi=-67,
-    )
-    result = parse_advertisement_data(
-        ble_device, adv_data, SwitchbotModel.RELAY_SWITCH_1PM
-    )
-    assert result == SwitchBotAdvertisement(
-        address="aa:bb:cc:dd:ee:ff",
-        data={
-            "data": {
-                "switchMode": True,
-                "sequence_number": 71,
-                "isOn": True,
-                "power": 4.9,
-                "voltage": 0,
-                "current": 0,
-            },
-            "isEncrypted": False,
-            "model": "<",
-            "modelFriendlyName": "Relay Switch 1PM",
-            "modelName": SwitchbotModel.RELAY_SWITCH_1PM,
-            "rawAdvData": b"<\x00\x00\x00",
-        },
-        device=ble_device,
-        rssi=-67,
-        active=True,
-    )
-
-
-def test_parse_advertisement_data_relay_switch_1():
-    """Test parse_advertisement_data for the keypad."""
-    ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
-    adv_data = generate_advertisement_data(
-        manufacturer_data={2409: b"$X|\x0866G\x81\x00\x00\x001\x00\x00\x00\x00"},
-        service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": b";\x00\x00\x00"},
-        rssi=-67,
-    )
-    result = parse_advertisement_data(
-        ble_device, adv_data, SwitchbotModel.RELAY_SWITCH_1
-    )
-    assert result == SwitchBotAdvertisement(
-        address="aa:bb:cc:dd:ee:ff",
-        data={
-            "data": {
-                "switchMode": True,
-                "sequence_number": 71,
-                "isOn": True,
-            },
-            "isEncrypted": False,
-            "model": ";",
-            "modelFriendlyName": "Relay Switch 1",
-            "modelName": SwitchbotModel.RELAY_SWITCH_1,
-            "rawAdvData": b";\x00\x00\x00",
-        },
-        device=ble_device,
-        rssi=-67,
-        active=True,
-    )
-
-
 def test_leak_active():
     """Test parse_advertisement_data for the leak detector."""
     ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
@@ -3082,6 +3017,272 @@ def test_blind_tilt_with_empty_data() -> None:
             "data": {},
             "isEncrypted": False,
             "model": "x",
+        },
+        device=ble_device,
+        rssi=-97,
+        active=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        AdvTestCase(
+            b'\xc0N0\xdd\xb9\xf2\x8a\xc1\x00\x00\x00\x00\x00F\x00\x00',
+            b'=\x00\x00\x00',
+            {
+                1: {
+                    'isOn': True,
+                    'power': 0.0,
+                    'sequence_number': 138,
+                    'switchMode': True,
+                },
+                2: {
+                    'isOn': True,
+                    'power': 7.0,
+                    'sequence_number': 138,
+                    'switchMode': True,
+                },
+            },
+            '=',
+            'Relay Switch 2PM',
+            SwitchbotModel.RELAY_SWITCH_2PM,
+        ),
+        AdvTestCase(
+            b"$X|\x0866G\x81\x00\x00\x001\x00\x00\x00\x00",
+            b";\x00\x00\x00",
+            {
+                'isOn': True,
+                "sequence_number": 71,
+                'switchMode': True,
+            },
+            ';',
+            'Relay Switch 1',
+            SwitchbotModel.RELAY_SWITCH_1,
+        ),
+        AdvTestCase(
+            b"$X|\x0866G\x81\x00\x00\x001\x00\x00\x00\x00",
+            b"<\x00\x00\x00",
+            {
+                'isOn': True,
+                'power': 4.9,
+                'sequence_number': 71,
+                'switchMode': True,
+            },
+            '<',
+            'Relay Switch 1PM',
+            SwitchbotModel.RELAY_SWITCH_1PM,
+        ),
+        AdvTestCase(
+            b'$X|\x05BN\x0f\x00\x00\x03\x00\x00\x00\x00\x00\x00',
+            b'>\x00\x00\x00',
+            {
+                'door_open': True,
+                'isOn': False,
+                'sequence_number': 15,
+                'switchMode': True,
+            },
+            '>',
+            'Garage Door Opener',
+            SwitchbotModel.GARAGE_DOOR_OPENER,
+        ),
+
+    ],
+)
+def test_adv_active(test_case: AdvTestCase) -> None:
+    """Test with active data."""
+    ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
+    adv_data = generate_advertisement_data(
+        manufacturer_data={2409: test_case.manufacturer_data},
+        service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": test_case.service_data},
+        rssi=-97,
+    )
+    result = parse_advertisement_data(ble_device, adv_data)
+    assert result == SwitchBotAdvertisement(
+        address="aa:bb:cc:dd:ee:ff",
+        data={
+            "rawAdvData": test_case.service_data,
+            "data": test_case.data,
+            "isEncrypted": False,
+            "model": test_case.model,
+            "modelFriendlyName": test_case.modelFriendlyName,
+            "modelName": test_case.modelName,
+        },
+        device=ble_device,
+        rssi=-97,
+        active=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        AdvTestCase(
+            b'\xc0N0\xdd\xb9\xf2\x8a\xc1\x00\x00\x00\x00\x00F\x00\x00',
+            b'=\x00\x00\x00',
+            {
+                1: {
+                    'isOn': True,
+                    'power': 0.0,
+                    'sequence_number': 138,
+                    'switchMode': True,
+                },
+                2: {
+                    'isOn': True,
+                    'power': 7.0,
+                    'sequence_number': 138,
+                    'switchMode': True,
+                },
+            },
+            '=',
+            'Relay Switch 2PM',
+            SwitchbotModel.RELAY_SWITCH_2PM,
+        ),
+        AdvTestCase(
+            b"$X|\x0866G\x81\x00\x00\x001\x00\x00\x00\x00",
+            b";\x00\x00\x00",
+            {
+                'isOn': True,
+                "sequence_number": 71,
+                'switchMode': True,
+            },
+            ';',
+            'Relay Switch 1',
+            SwitchbotModel.RELAY_SWITCH_1,
+        ),
+        AdvTestCase(
+            b"$X|\x0866G\x81\x00\x00\x001\x00\x00\x00\x00",
+            b"<\x00\x00\x00",
+            {
+                'isOn': True,
+                'power': 4.9,
+                'sequence_number': 71,
+                'switchMode': True,
+            },
+            '<',
+            'Relay Switch 1PM',
+            SwitchbotModel.RELAY_SWITCH_1PM,
+        ),
+        AdvTestCase(
+            b'$X|\x05BN\x0f\x00\x00\x03\x00\x00\x00\x00\x00\x00',
+            b'>\x00\x00\x00',
+            {
+                'door_open': True,
+                'isOn': False,
+                'sequence_number': 15,
+                'switchMode': True,
+            },
+            '>',
+            'Garage Door Opener',
+            SwitchbotModel.GARAGE_DOOR_OPENER,
+        ),
+
+    ],
+)
+def test_adv_passive(test_case: AdvTestCase) -> None:
+    """Test with passive data."""
+    ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
+    adv_data = generate_advertisement_data(
+        manufacturer_data={2409: test_case.manufacturer_data},
+        rssi=-97,
+    )
+    result = parse_advertisement_data(ble_device, adv_data, test_case.modelName)
+    assert result == SwitchBotAdvertisement(
+        address="aa:bb:cc:dd:ee:ff",
+        data={
+            "rawAdvData": None,
+            "data": test_case.data,
+            "isEncrypted": False,
+            "model": test_case.model,
+            "modelFriendlyName": test_case.modelFriendlyName,
+            "modelName": test_case.modelName,
+        },
+        device=ble_device,
+        rssi=-97,
+        active=False,
+    )
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        AdvTestCase(
+            None,
+            b'=\x00\x00\x00',
+            {
+                1: {
+                    'isOn': True,
+                    'power': 0.0,
+                    'sequence_number': 138,
+                    'switchMode': True,
+                },
+                2: {
+                    'isOn': True,
+                    'power': 7.0,
+                    'sequence_number': 138,
+                    'switchMode': True,
+                },
+            },
+            '=',
+            'Relay Switch 2PM',
+            SwitchbotModel.RELAY_SWITCH_2PM,
+        ),
+        AdvTestCase(
+            None,
+            b";\x00\x00\x00",
+            {
+                'isOn': True,
+                "sequence_number": 71,
+                'switchMode': True,
+            },
+            ';',
+            'Relay Switch 1',
+            SwitchbotModel.RELAY_SWITCH_1,
+        ),
+        AdvTestCase(
+            None,
+            b"<\x00\x00\x00",
+            {
+                'isOn': True,
+                'power': 4.9,
+                'sequence_number': 71,
+                'switchMode': True,
+            },
+            '<',
+            'Relay Switch 1PM',
+            SwitchbotModel.RELAY_SWITCH_1PM,
+        ),
+        AdvTestCase(
+            None,
+            b'>\x00\x00\x00',
+            {
+                'door_open': True,
+                'isOn': False,
+                'sequence_number': 15,
+                'switchMode': True,
+            },
+            '>',
+            'Garage Door Opener',
+            SwitchbotModel.GARAGE_DOOR_OPENER,
+        ),
+
+    ],
+)
+def test_adv_with_empty_data(test_case: AdvTestCase) -> None:
+    """Test with empty data."""
+    ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
+    adv_data = generate_advertisement_data(
+        manufacturer_data={2409: None},
+        service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": test_case.service_data},
+        rssi=-97,
+    )
+    result = parse_advertisement_data(ble_device, adv_data)
+    assert result == SwitchBotAdvertisement(
+        address="aa:bb:cc:dd:ee:ff",
+        data={
+            "rawAdvData": test_case.service_data,
+            "data": {},
+            "isEncrypted": False,
+            "model": test_case.model,
         },
         device=ble_device,
         rssi=-97,

--- a/tests/test_relay_switch.py
+++ b/tests/test_relay_switch.py
@@ -223,13 +223,13 @@ async def test_get_basic_info_2PM(common_parametrize_2pm, info_data, result):
     assert 2 in info
 
     assert info[1]["isOn"] == result[0]
-    assert info[1]["electricity"] == result[1]
+    assert info[1]["energy"] == result[1]
     assert info[1]["voltage"] == result[2]
     assert info[1]["current"] == result[3]
     assert info[1]["power"] == result[4]
 
     assert info[2]["isOn"] == result[5]
-    assert info[2]["electricity"] == result[6]
+    assert info[2]["energy"] == result[6]
     assert info[2]["voltage"] == result[7]
     assert info[2]["current"] == result[8]
     assert info[2]["power"] == result[9]

--- a/tests/test_relay_switch.py
+++ b/tests/test_relay_switch.py
@@ -185,7 +185,7 @@ async def test_get_switch_mode_2PM(common_parametrize_2pm):
                 "channel1_info": b'\x01\x00\x00\x00\x00\x00\x00\x02\x99\x00\xe9\x00\x03\x00\x00',
                 "channel2_info": b"\x01\x00\x055\x00'<\x02\x9f\x00\xe9\x01,\x00F",
             },
-            [False, 0, 0, 0, 0, True, 0.02, 23.3, 300, 7.0],
+            [False, 0, 0, 0, 0, True, 0.02, 23, 0.3, 7.0],
         ),
         (
             {
@@ -193,7 +193,7 @@ async def test_get_switch_mode_2PM(common_parametrize_2pm):
                 "channel1_info": b'\x01\x00\x00\x00\x00\x00\x00\x02\x99\x00\xe9\x00\x03\x00\x00',
                 "channel2_info": b"\x01\x00\x05\xbc\x00'<\x02\xb1\x00\xea\x01-\x00F",
             },
-            [True, 0, 23.3, 3, 0.0, False, 0.02, 0, 0, 0],
+            [True, 0, 23, 0.1, 0.0, False, 0.02, 0, 0, 0],
         )
     ],
 )

--- a/tests/test_relay_switch.py
+++ b/tests/test_relay_switch.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from bleak.backends.device import BLEDevice
@@ -9,65 +9,172 @@ from switchbot.devices import relay_switch
 from .test_adv_parser import generate_ble_device
 
 
-def create_device_for_command_testing(calibration=True, reverse_mode=False):
+def create_device_for_command_testing(
+    rawAdvData: bytes, model: str, init_data: dict | None = None):
+    """Create a device for command testing."""
     ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
-    relay_switch_device = relay_switch.SwitchbotRelaySwitch(
+    device_class = (
+        relay_switch.SwitchbotRelaySwitch2PM
+        if model == SwitchbotModel.RELAY_SWITCH_2PM
+        else relay_switch.SwitchbotRelaySwitch
+    )
+    device = device_class(
         ble_device, "ff", "ffffffffffffffffffffffffffffffff"
     )
-    relay_switch_device.update_from_advertisement(make_advertisement_data(ble_device))
-    return relay_switch_device
-
-
-def make_advertisement_data(ble_device: BLEDevice):
-    """Set advertisement data with defaults."""
-    return SwitchBotAdvertisement(
-        address="aa:bb:cc:dd:ee:ff",
-        data={
-            "rawAdvData": b"$X|\x0866G\x81\x00\x00\x001\x00\x00\x00\x00",
-            "data": {
-                "switchMode": True,
-                "sequence_number": 71,
-                "isOn": True,
-                "power": 4.9,
-                "voltage": 0,
-                "current": 0,
-            },
-            "isEncrypted": False,
-            "model": "<",
-            "modelFriendlyName": "Relay Switch 1PM",
-            "modelName": SwitchbotModel.RELAY_SWITCH_1PM,
-        },
-        device=ble_device,
-        rssi=-80,
-        active=True,
+    device.update_from_advertisement(
+        make_advertisement_data(ble_device, rawAdvData, model, init_data)
     )
+    device._send_command = AsyncMock()
+    device._check_command_result = MagicMock()
+    device.update = AsyncMock()
+    return device
+
+def make_advertisement_data(
+    ble_device: BLEDevice, rawAdvData: bytes, model: str, init_data: dict | None = None
+):
+    """Set advertisement data with defaults."""
+    if init_data is None:
+        init_data = {}
+    if model == SwitchbotModel.RELAY_SWITCH_2PM:
+        return SwitchBotAdvertisement(
+            address="aa:bb:cc:dd:ee:ff",
+            data={
+                "rawAdvData": rawAdvData,
+                "data": {
+                    1: {
+                        "switchMode": True,
+                        "sequence_number": 99,
+                        "isOn": True,
+                    },
+                    2: {
+                        "switchMode": True,
+                        "sequence_number": 99,
+                        "isOn": False,
+                    },
+                }
+                | init_data,
+                "isEncrypted": False,
+                "model": model,
+                "modelFriendlyName": "Relay Switch 2PM",
+                "modelName": SwitchbotModel.RELAY_SWITCH_2PM,
+            },
+            device=ble_device,
+            rssi=-80,
+            active=True,
+        )
+    return None
 
 
 @pytest.mark.asyncio
-async def test_turn_on():
-    relay_switch_device = create_device_for_command_testing()
-    relay_switch_device._send_command = AsyncMock(return_value=b"\x01")
-    await relay_switch_device.turn_on()
-    assert relay_switch_device.is_on() is True
+@pytest.mark.parametrize(
+    ("rawAdvData", "model", "init_data"),
+    [
+        (
+            b"\x00\x00\x00\x00\x00\x00",
+            SwitchbotModel.RELAY_SWITCH_2PM,
+            {1: {"isOn": True}, 2: {"isOn": True}},
+        ),
+    ],
+)
+async def test_turn_on_2PM(rawAdvData, model, init_data):
+    """Test turn on command."""
+    device = create_device_for_command_testing(rawAdvData, model, init_data)
+    await device.turn_on(1)
+    device._send_command.assert_called_with(
+        relay_switch.MULTI_CHANNEL_COMMANDS_TURN_ON[model][1]
+    )
+    assert device.is_on(1) is True
+
+    await device.turn_on(2)
+    device._send_command.assert_called_with(
+        relay_switch.MULTI_CHANNEL_COMMANDS_TURN_ON[model][2]
+    )
+    assert device.is_on(2) is True
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("rawAdvData", "model", "init_data"),
+    [
+        (
+            b"\x00\x00\x00\x00\x00\x00",
+            SwitchbotModel.RELAY_SWITCH_2PM,
+            {1: {"isOn": False}, 2: {"isOn": False}},
+        ),
+    ],
+)
+async def test_turn_off_2PM(rawAdvData, model, init_data):
+    """Test turn off command."""
+    device = create_device_for_command_testing(rawAdvData, model, init_data)
+    await device.turn_off(1)
+    device._send_command.assert_called_with(
+        relay_switch.MULTI_CHANNEL_COMMANDS_TURN_OFF[model][1]
+    )
+    assert device.is_on(1) is False
+
+    await device.turn_off(2)
+    device._send_command.assert_called_with(
+        relay_switch.MULTI_CHANNEL_COMMANDS_TURN_OFF[model][2]
+    )
+    assert device.is_on(2) is False
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("rawAdvData", "model"),
+    [
+        (
+            b"\x00\x00\x00\x00\x00\x00",
+            SwitchbotModel.RELAY_SWITCH_2PM,
+        ),
+    ],
+)
+async def test_turn_toggle_2PM(rawAdvData, model):
+    """Test toggle command."""
+    device = create_device_for_command_testing(rawAdvData, model)
+    await device.async_toggle(1)
+    device._send_command.assert_called_with(
+        relay_switch.MULTI_CHANNEL_COMMANDS_TOGGLE[model][1]
+    )
+    assert device.is_on(1) is True
+
+    await device.async_toggle(2)
+    device._send_command.assert_called_with(
+        relay_switch.MULTI_CHANNEL_COMMANDS_TOGGLE[model][2]
+    )
+    assert device.is_on(2) is False
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("rawAdvData", "model"),
+    [
+        (
+            b"\x00\x00\x00\x00\x00\x00",
+            SwitchbotModel.RELAY_SWITCH_2PM,
+        ),
+    ],
+)
+async def test_get_switch_mode_2PM(rawAdvData, model):
+    """Test get switch mode."""
+    device = create_device_for_command_testing(rawAdvData, model)
+    assert device.switch_mode(1) is True
+    assert device.switch_mode(2) is True
 
 
 @pytest.mark.asyncio
-async def test_turn_off():
-    relay_switch_device = create_device_for_command_testing()
-    relay_switch_device._send_command = AsyncMock(return_value=b"\x01")
-    await relay_switch_device.turn_off()
-    assert relay_switch_device.is_on() is False
+@pytest.mark.parametrize(
+    ("rawAdvData", "model"),
+    [
+        (
+            b"\x00\x00\x00\x00\x00\x00",
+            SwitchbotModel.RELAY_SWITCH_2PM,
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    ("channel1_info", "channel2_info"), [(True, False), (False, True), (False, False)]
+)
+async def test_get_basic_info_returns_none(rawAdvData, model, channel1_info, channel2_info):
+    device = create_device_for_command_testing(rawAdvData, model)
+
+    device.get_current_time_and_start_time = MagicMock(return_value=("683074d6", "682fba80"))
 
 
-@pytest.mark.asyncio
-async def test_get_basic_info():
-    relay_switch_device = create_device_for_command_testing()
-    relay_switch_device._send_command = AsyncMock(return_value=b"\x01\x01")
-    info = await relay_switch_device.get_basic_info()
-    assert info["is_on"] is True
-    relay_switch_device._send_command = AsyncMock(return_value=b"\x01\x00")
-    info = await relay_switch_device.get_basic_info()
-    assert info["is_on"] is False
-    relay_switch_device._send_command = AsyncMock(return_value=b"\x00\x00")
-    info = await relay_switch_device.get_basic_info()
-    assert info is None

--- a/tests/test_relay_switch.py
+++ b/tests/test_relay_switch.py
@@ -1,12 +1,27 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from bleak.backends.device import BLEDevice
 
-from switchbot import SwitchBotAdvertisement, SwitchbotModel
+from switchbot import SwitchBotAdvertisement, SwitchbotEncryptedDevice, SwitchbotModel
 from switchbot.devices import relay_switch
 
 from .test_adv_parser import generate_ble_device
+
+common_params = [
+    (b";\x00\x00\x00", SwitchbotModel.RELAY_SWITCH_1),
+    (b"<\x00\x00\x00", SwitchbotModel.RELAY_SWITCH_1PM),
+    (b'>\x00\x00\x00', SwitchbotModel.GARAGE_DOOR_OPENER),
+]
+
+
+@pytest.fixture
+def common_parametrize_2pm():
+    """Provide common test data."""
+    return {
+        "rawAdvData": b"\x00\x00\x00\x00\x00\x00",
+        "model": SwitchbotModel.RELAY_SWITCH_2PM,
+    }
 
 
 def create_device_for_command_testing(
@@ -19,7 +34,7 @@ def create_device_for_command_testing(
         else relay_switch.SwitchbotRelaySwitch
     )
     device = device_class(
-        ble_device, "ff", "ffffffffffffffffffffffffffffffff"
+        ble_device, "ff", "ffffffffffffffffffffffffffffffff", model=model
     )
     device.update_from_advertisement(
         make_advertisement_data(ble_device, rawAdvData, model, init_data)
@@ -54,127 +69,332 @@ def make_advertisement_data(
                 }
                 | init_data,
                 "isEncrypted": False,
-                "model": model,
-                "modelFriendlyName": "Relay Switch 2PM",
-                "modelName": SwitchbotModel.RELAY_SWITCH_2PM,
             },
             device=ble_device,
             rssi=-80,
             active=True,
         )
-    return None
-
+    if model == SwitchbotModel.GARAGE_DOOR_OPENER:
+        return SwitchBotAdvertisement(
+            address="aa:bb:cc:dd:ee:ff",
+            data={
+                "rawAdvData": rawAdvData,
+                "data": {
+                    "switchMode": True,
+                    "sequence_number": 96,
+                    "isOn": True,
+                    "door_open": False,
+                } | init_data,
+                "isEncrypted": False,
+            },
+            device=ble_device,
+            rssi=-80,
+            active=True,
+        )
+    return SwitchBotAdvertisement(
+        address="aa:bb:cc:dd:ee:ff",
+        data={
+            "rawAdvData": rawAdvData,
+            "data": {
+                "switchMode": True,
+                "sequence_number": 96,
+                "isOn": True,
+            }
+            | init_data,
+            "isEncrypted": False,
+        },
+        device=ble_device,
+        rssi=-80,
+        active=True,
+    )
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("rawAdvData", "model", "init_data"),
+    "init_data",
     [
-        (
-            b"\x00\x00\x00\x00\x00\x00",
-            SwitchbotModel.RELAY_SWITCH_2PM,
-            {1: {"isOn": True}, 2: {"isOn": True}},
-        ),
+        {1: {"isOn": True}, 2: {"isOn": True}},
     ],
 )
-async def test_turn_on_2PM(rawAdvData, model, init_data):
+async def test_turn_on_2PM(common_parametrize_2pm, init_data):
     """Test turn on command."""
-    device = create_device_for_command_testing(rawAdvData, model, init_data)
+    device = create_device_for_command_testing(common_parametrize_2pm["rawAdvData"], common_parametrize_2pm["model"], init_data)
     await device.turn_on(1)
     device._send_command.assert_called_with(
-        relay_switch.MULTI_CHANNEL_COMMANDS_TURN_ON[model][1]
+        relay_switch.MULTI_CHANNEL_COMMANDS_TURN_ON[common_parametrize_2pm["model"]][1]
     )
     assert device.is_on(1) is True
 
     await device.turn_on(2)
     device._send_command.assert_called_with(
-        relay_switch.MULTI_CHANNEL_COMMANDS_TURN_ON[model][2]
+        relay_switch.MULTI_CHANNEL_COMMANDS_TURN_ON[common_parametrize_2pm["model"]][2]
     )
     assert device.is_on(2) is True
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("rawAdvData", "model", "init_data"),
+    "init_data",
     [
-        (
-            b"\x00\x00\x00\x00\x00\x00",
-            SwitchbotModel.RELAY_SWITCH_2PM,
-            {1: {"isOn": False}, 2: {"isOn": False}},
-        ),
+        {1: {"isOn": False}, 2: {"isOn": False}},
     ],
 )
-async def test_turn_off_2PM(rawAdvData, model, init_data):
+async def test_turn_off_2PM(common_parametrize_2pm, init_data):
     """Test turn off command."""
-    device = create_device_for_command_testing(rawAdvData, model, init_data)
+    device = create_device_for_command_testing(common_parametrize_2pm["rawAdvData"], common_parametrize_2pm["model"], init_data)
     await device.turn_off(1)
     device._send_command.assert_called_with(
-        relay_switch.MULTI_CHANNEL_COMMANDS_TURN_OFF[model][1]
+        relay_switch.MULTI_CHANNEL_COMMANDS_TURN_OFF[common_parametrize_2pm["model"]][1]
     )
     assert device.is_on(1) is False
 
     await device.turn_off(2)
     device._send_command.assert_called_with(
-        relay_switch.MULTI_CHANNEL_COMMANDS_TURN_OFF[model][2]
+        relay_switch.MULTI_CHANNEL_COMMANDS_TURN_OFF[common_parametrize_2pm["model"]][2]
     )
     assert device.is_on(2) is False
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("rawAdvData", "model"),
-    [
-        (
-            b"\x00\x00\x00\x00\x00\x00",
-            SwitchbotModel.RELAY_SWITCH_2PM,
-        ),
-    ],
-)
-async def test_turn_toggle_2PM(rawAdvData, model):
+async def test_turn_toggle_2PM(common_parametrize_2pm):
     """Test toggle command."""
-    device = create_device_for_command_testing(rawAdvData, model)
+    device = create_device_for_command_testing(common_parametrize_2pm["rawAdvData"], common_parametrize_2pm["model"])
     await device.async_toggle(1)
     device._send_command.assert_called_with(
-        relay_switch.MULTI_CHANNEL_COMMANDS_TOGGLE[model][1]
+        relay_switch.MULTI_CHANNEL_COMMANDS_TOGGLE[common_parametrize_2pm["model"]][1]
     )
     assert device.is_on(1) is True
 
     await device.async_toggle(2)
     device._send_command.assert_called_with(
-        relay_switch.MULTI_CHANNEL_COMMANDS_TOGGLE[model][2]
+        relay_switch.MULTI_CHANNEL_COMMANDS_TOGGLE[common_parametrize_2pm["model"]][2]
     )
     assert device.is_on(2) is False
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("rawAdvData", "model"),
-    [
-        (
-            b"\x00\x00\x00\x00\x00\x00",
-            SwitchbotModel.RELAY_SWITCH_2PM,
-        ),
-    ],
-)
-async def test_get_switch_mode_2PM(rawAdvData, model):
+async def test_get_switch_mode_2PM(common_parametrize_2pm):
     """Test get switch mode."""
-    device = create_device_for_command_testing(rawAdvData, model)
+    device = create_device_for_command_testing(common_parametrize_2pm["rawAdvData"], common_parametrize_2pm["model"])
     assert device.switch_mode(1) is True
     assert device.switch_mode(2) is True
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("info_data", "result"),
+    [
+        (
+            {
+                "basic_info": b'\x01\x98A\x0c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x10',
+                "channel1_info": b'\x01\x00\x00\x00\x00\x00\x00\x02\x99\x00\xe9\x00\x03\x00\x00',
+                "channel2_info": b"\x01\x00\x055\x00'<\x02\x9f\x00\xe9\x01,\x00F",
+            },
+            [False, 0, 0, 0, 0, True, 0.02, 23.3, 300, 7.0],
+        ),
+        (
+            {
+                "basic_info": b'\x01\x9e\x81\x0c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x10',
+                "channel1_info": b'\x01\x00\x00\x00\x00\x00\x00\x02\x99\x00\xe9\x00\x03\x00\x00',
+                "channel2_info": b"\x01\x00\x05\xbc\x00'<\x02\xb1\x00\xea\x01-\x00F",
+            },
+            [True, 0, 23.3, 3, 0.0, False, 0.02, 0, 0, 0],
+        )
+    ],
+)
+async def test_get_basic_info_2PM(common_parametrize_2pm, info_data, result):
+    """Test get_basic_info for 2PM devices."""
+    device = create_device_for_command_testing(common_parametrize_2pm["rawAdvData"], common_parametrize_2pm["model"])
+
+    assert device.channel == 2
+
+    device.get_current_time_and_start_time = MagicMock(return_value=("683074d6", "682fba80"))
+
+    async def mock_get_basic_info(arg):
+        if arg == relay_switch.COMMAND_GET_BASIC_INFO:
+            return info_data["basic_info"]
+        if arg == relay_switch.COMMAND_GET_CHANNEL1_INFO.format("683074d6", "682fba80"):
+            return info_data["channel1_info"]
+        if arg == relay_switch.COMMAND_GET_CHANNEL2_INFO.format("683074d6", "682fba80"):
+            return info_data["channel2_info"]
+        return None
+
+    device._get_basic_info = AsyncMock(side_effect=mock_get_basic_info)
+
+    info = await device.get_basic_info()
+
+    assert info is not None
+    assert 1 in info
+    assert 2 in info
+
+    assert info[1]["isOn"] == result[0]
+    assert info[1]["electricity"] == result[1]
+    assert info[1]["voltage"] == result[2]
+    assert info[1]["current"] == result[3]
+    assert info[1]["power"] == result[4]
+
+    assert info[2]["isOn"] == result[5]
+    assert info[2]["electricity"] == result[6]
+    assert info[2]["voltage"] == result[7]
+    assert info[2]["current"] == result[8]
+    assert info[2]["power"] == result[9]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "info_data",
+    [
+        {
+            "basic_info": None,
+            "channel1_info": b'\x01\x00\x00\x00\x00\x00\x00\x02\x99\x00\xe9\x00\x03\x00\x00',
+            "channel2_info": b"\x01\x00\x055\x00'<\x02\x9f\x00\xe9\x01,\x00F",
+        },
+        {
+            "basic_info": b'\x01\x98A\x0c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x10',
+            "channel1_info": None,
+            "channel2_info": b"\x01\x00\x055\x00'<\x02\x9f\x00\xe9\x01,\x00F",
+        },
+        {
+            "basic_info": b'\x01\x98A\x0c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x10',
+            "channel1_info": b'\x01\x00\x00\x00\x00\x00\x00\x02\x99\x00\xe9\x00\x03\x00\x00',
+            "channel2_info": None,
+        },
+    ],
+)
+async def test_basic_info_exceptions_2PM(common_parametrize_2pm, info_data):
+    """Test get_basic_info exceptions."""
+    device = create_device_for_command_testing(common_parametrize_2pm["rawAdvData"], common_parametrize_2pm["model"])
+
+    device.get_current_time_and_start_time = MagicMock(return_value=("683074d6", "682fba80"))
+
+    async def mock_get_basic_info(arg):
+        if arg == relay_switch.COMMAND_GET_BASIC_INFO:
+            return info_data["basic_info"]
+        if arg == relay_switch.COMMAND_GET_CHANNEL1_INFO.format("683074d6", "682fba80"):
+            return info_data["channel1_info"]
+        if arg == relay_switch.COMMAND_GET_CHANNEL2_INFO.format("683074d6", "682fba80"):
+            return info_data["channel2_info"]
+        return None
+
+    device._get_basic_info = AsyncMock(side_effect=mock_get_basic_info)
+
+    info = await device.get_basic_info()
+
+    assert info is None
+
+
+@pytest.mark.asyncio
+async def test_get_parsed_data_2PM(common_parametrize_2pm):
+    """Test get_parsed_data for 2PM devices."""
+    device = create_device_for_command_testing(common_parametrize_2pm["rawAdvData"], common_parametrize_2pm["model"])
+
+    info = device.get_parsed_data(1)
+    assert info["isOn"] is True
+
+    info = device.get_parsed_data(2)
+    assert info["isOn"] is False
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("rawAdvData", "model"),
+    common_params,
+)
+async def test_turn_on(rawAdvData, model):
+    """Test turn on command."""
+    device = create_device_for_command_testing(rawAdvData, model)
+    await device.turn_on()
+    device._send_command.assert_awaited_once_with(
+        relay_switch.COMMAND_TURN_ON
+    )
+    assert device.is_on() is True
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("rawAdvData", "model"),
+    common_params,
+)
+async def test_turn_off(rawAdvData, model):
+    """Test turn off command."""
+    device = create_device_for_command_testing(rawAdvData, model, {"isOn": False})
+    await device.turn_off()
+    device._send_command.assert_awaited_once_with(
+        relay_switch.COMMAND_TURN_OFF
+    )
+    assert device.is_on() is False
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("rawAdvData", "model"),
+    common_params,
+)
+async def test_toggle(rawAdvData, model):
+    """Test toggle command."""
+    device = create_device_for_command_testing(rawAdvData, model)
+    await device.async_toggle()
+    device._send_command.assert_awaited_once_with(
+        relay_switch.COMMAND_TOGGLE
+    )
+    assert device.is_on() is True
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("rawAdvData", "model", "info_data"),
     [
         (
-            b"\x00\x00\x00\x00\x00\x00",
-            SwitchbotModel.RELAY_SWITCH_2PM,
-        ),
+            b'>\x00\x00\x00',
+            SwitchbotModel.GARAGE_DOOR_OPENER,
+            {
+                "basic_info": b'\x01>\x80\x0c\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x10',
+                "channel1_info": b'\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+            },
+        )
+    ]
+)
+async def test_get_basic_info_garage_door_opener(rawAdvData, model, info_data):
+    """Test get_basic_info for garage door opener."""
+    device = create_device_for_command_testing(rawAdvData, model)
+    device.get_current_time_and_start_time = MagicMock(return_value=("683074d6", "682fba80"))
+    async def mock_get_basic_info(arg):
+        if arg == relay_switch.COMMAND_GET_BASIC_INFO:
+            return info_data["basic_info"]
+        if arg == relay_switch.COMMAND_GET_CHANNEL1_INFO.format("683074d6", "682fba80"):
+            return info_data["channel1_info"]
+        return None
+    device._get_basic_info = AsyncMock(side_effect=mock_get_basic_info)
+    info = await device.get_basic_info()
+    assert info is not None
+    assert info["isOn"] is True
+    assert info["door_open"] is True
+
+
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model",
+    [
+        SwitchbotModel.RELAY_SWITCH_1,
+        SwitchbotModel.RELAY_SWITCH_1PM,
+        SwitchbotModel.GARAGE_DOOR_OPENER,
+        SwitchbotModel.RELAY_SWITCH_2PM,
     ],
 )
-@pytest.mark.parametrize(
-    ("channel1_info", "channel2_info"), [(True, False), (False, True), (False, False)]
-)
-async def test_get_basic_info_returns_none(rawAdvData, model, channel1_info, channel2_info):
-    device = create_device_for_command_testing(rawAdvData, model)
+@patch.object(SwitchbotEncryptedDevice, "verify_encryption_key", new_callable=AsyncMock)
+async def test_verify_encryption_key(mock_parent_verify, model):
+    ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
+    key_id = "ff"
+    encryption_key = "ffffffffffffffffffffffffffffffff"
 
-    device.get_current_time_and_start_time = MagicMock(return_value=("683074d6", "682fba80"))
+    mock_parent_verify.return_value = True
 
+    result = await relay_switch.SwitchbotRelaySwitch.verify_encryption_key(
+        device=ble_device,
+        key_id=key_id,
+        encryption_key=encryption_key,
+        model=model,
+    )
 
+    mock_parent_verify.assert_awaited_once_with(
+        ble_device,
+        key_id,
+        encryption_key,
+        model,
+    )
+
+    assert result is True


### PR DESCRIPTION
- optimize relay switch 1
- optimize relay swicth 1 PM
- add garage door opener
- add relay switch 2 PM

Implement preliminary support for the listed devices to facilitate Home Assistant (HA) integration readiness.

Note: The relay switch 2PM has two independent switch channels