### PR TITLE
Remove rssi call on the BLEDevice

### DIFF
--- a/switchbot/devices/device.py
+++ b/switchbot/devices/device.py
@@ -295,7 +295,7 @@ class SwitchbotBaseDevice:
         """Return RSSI of device."""
         if self._sb_adv_data:
             return self._sb_adv_data.rssi
-        return self._device.rssi
+        return -127
 
     async def _ensure_connected(self):
         """Ensure connection to device is established."""


### PR DESCRIPTION
bleak 1.x removes .rssi from BLEDevice