### PR TITLE
Fix race condition when decrypting notifications during lock disconnection

### DIFF
--- a/switchbot/devices/device.py
+++ b/switchbot/devices/device.py
@@ -955,6 +955,12 @@ class SwitchbotEncryptedDevice(SwitchbotDevice):
         if len(data) == 0:
             return b""
         if self._iv is None:
+            if self._expected_disconnect:
+                _LOGGER.debug(
+                    "%s: Cannot decrypt, IV is None during expected disconnect",
+                    self.name,
+                )
+                return b""
             raise RuntimeError("Cannot decrypt: IV is None")
         decryptor = self._get_cipher().decryptor()
         return decryptor.update(data) + decryptor.finalize()

--- a/tests/test_encrypted_device.py
+++ b/tests/test_encrypted_device.py
@@ -365,3 +365,22 @@ async def test_empty_data_encryption_decryption() -> None:
     # Test empty decryption
     decrypted = device._decrypt(bytearray())
     assert decrypted == b""
+
+
+@pytest.mark.asyncio
+async def test_decrypt_with_none_iv_during_disconnect() -> None:
+    """Test that decryption returns empty bytes when IV is None during expected disconnect."""
+    device = create_encrypted_device()
+
+    # Simulate disconnection in progress
+    device._expected_disconnect = True
+    device._iv = None
+
+    # Should return empty bytes instead of raising
+    result = device._decrypt(bytearray(b"encrypted_data"))
+    assert result == b""
+
+    # Verify it still raises when not disconnecting
+    device._expected_disconnect = False
+    with pytest.raises(RuntimeError, match="Cannot decrypt: IV is None"):
+        device._decrypt(bytearray(b"encrypted_data"))


### PR DESCRIPTION
## Fix race condition when decrypting notifications during lock disconnection

Fixes #353 

### Problem
A race condition occurs when encrypted notifications arrive during device disconnection:
1. Encrypted command sent to lock
2. Device starts disconnecting (clears IV)
3. Notification arrives with encrypted response
4. `_decrypt` fails with `RuntimeError: Cannot decrypt: IV is None`

This timing-dependent issue is hard to reproduce and may vary across Bluetooth stacks.

### Solution
Modified `_decrypt` to gracefully handle missing IV during expected disconnection:
- Check `_expected_disconnect` flag before raising error
- Log debug message and return empty bytes during disconnection
- Still raise `RuntimeError` for genuine IV issues

### Testing
Added test `test_decrypt_with_none_iv_during_disconnect` to verify the fix works correctly.