### PR TITLE
Fix periodic reporting status for lock series

### DIFF
--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -372,27 +372,6 @@ async def test_enable_notifications(model: str):
     with patch.object(device, "_send_command", return_value=b"\x01\x00"):
         result = await device._enable_notifications()
         assert result is True
-        assert device._notifications_enabled is True
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "model",
-    [
-        SwitchbotModel.LOCK,
-        SwitchbotModel.LOCK_LITE,
-        SwitchbotModel.LOCK_PRO,
-        SwitchbotModel.LOCK_ULTRA,
-    ],
-)
-async def test_enable_notifications_already_enabled(model: str):
-    """Test _enable_notifications when already enabled."""
-    device = create_device_for_command_testing(model)
-    device._notifications_enabled = True
-    with patch.object(device, "_send_command") as mock_send:
-        result = await device._enable_notifications()
-        assert result is True
-        mock_send.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -467,7 +446,7 @@ def test_notification_handler_not_enabled(model: str):
     """Test _notification_handler when notifications not enabled."""
     device = create_device_for_command_testing(model)
     device._notifications_enabled = False
-    data = bytearray(b"\x0f\x00\x00\x00\x80\x00\x00\x00\x00\x00")
+    data = bytearray(b"\x01\x00\x00\x00\x80\x00\x00\x00\x00\x00")
     with (
         patch.object(device, "_update_lock_status") as mock_update,
         patch.object(


### PR DESCRIPTION
 - suggest remove the lock periodic reporting status when perfoming an action lock or unlock, which contains error status and sometimes causes the status to be overwritten immediately
 - Normally, when we perform a locking or unlocking action, we will actively query the lock status once. At this time, the locking or unlocking action may not have been completed. Then, when the BLE scan detects a change in the device broadcast, we will also actively update the status once. Through these two methods, we can ensure that the final state of the lock is correct.

![20250709-185032](https://github.com/user-attachments/assets/6e53bcef-5e41-4f34-8d52-6ab3c1dae856)
![20250709-185025](https://github.com/user-attachments/assets/6b23c8d5-b7a4-4dff-91c1-5474f69d12a2)
