### PR TITLE
fix evaporative humidifier mode settings

### DIFF
--- a/switchbot/devices/evaporative_humidifier.py
+++ b/switchbot/devices/evaporative_humidifier.py
@@ -149,8 +149,11 @@ class SwitchbotEvaporativeHumidifier(SwitchbotSequenceDevice, SwitchbotEncrypted
         result = await self._send_command(command)
         return self._check_command_result(result, 0, {1})
 
-    def _validate_water_level(self) -> None:
+    def _validate_water_level(self, mode: HumidifierMode | None = None) -> None:
         """Validate that the water level is not empty."""
+        if mode == HumidifierMode.DRYING_FILTER:
+            return
+
         if self.get_water_level() == HumidifierWaterLevel.EMPTY.name.lower():
             raise SwitchbotOperationError(
                 "Cannot perform operation when water tank is empty"

--- a/tests/test_evaporative_humidifier.py
+++ b/tests/test_evaporative_humidifier.py
@@ -250,6 +250,7 @@ async def test_set_target_humidity():
 async def test_set_mode(mode, command):
     """Test setting mode."""
     device = create_device_for_command_testing()
+    device._validate_water_level(mode)
     device.get_target_humidity = MagicMock(return_value=45)
 
     await device.set_mode(mode)


### PR DESCRIPTION
For DRYING_FILTER mode, it is not necessary to determine whether there is water in the water tank.
To fix issue: https://github.com/home-assistant/core/issues/148829