### PR TITLE
Fix device discovery when Bluetooth adapter is in passive scanning mode

### DIFF
--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -36,6 +36,7 @@ from .devices.device import (
     SwitchbotDevice,
     SwitchbotEncryptedDevice,
     SwitchbotOperationError,
+    fetch_cloud_devices,
 )
 from .devices.evaporative_humidifier import SwitchbotEvaporativeHumidifier
 from .devices.fan import SwitchbotFan
@@ -104,6 +105,7 @@ __all__ = [
     "SwitchbotVacuum",
     "close_stale_connections",
     "close_stale_connections_by_address",
+    "fetch_cloud_devices",
     "get_device",
     "parse_advertisement_data",
 ]

--- a/switchbot/adv_parser.py
+++ b/switchbot/adv_parser.py
@@ -45,6 +45,7 @@ from .adv_parsers.roller_shade import process_worollershade
 from .adv_parsers.vacuum import process_vacuum, process_vacuum_k
 from .const import SwitchbotModel
 from .models import SwitchBotAdvertisement
+from .utils import format_mac_upper
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,6 +54,33 @@ SERVICE_DATA_ORDER = (
     "00000d00-0000-1000-8000-00805f9b34fb",
 )
 MFR_DATA_ORDER = (2409, 741, 89)
+
+MODEL_TO_MAC_CACHE: dict[str, SwitchbotModel] = {}
+
+# Mapping from API model names to SwitchbotModel enum values
+API_MODEL_TO_ENUM: dict[str, SwitchbotModel] = {
+    "WoHand": SwitchbotModel.BOT,
+    "WoCurtain": SwitchbotModel.CURTAIN,
+    "WoHumi": SwitchbotModel.HUMIDIFIER,
+    "WoPlug": SwitchbotModel.PLUG_MINI,
+    "WoPlugUS": SwitchbotModel.PLUG_MINI,
+    "WoContact": SwitchbotModel.CONTACT_SENSOR,
+    "WoStrip": SwitchbotModel.LIGHT_STRIP,
+    "WoSensorTH": SwitchbotModel.METER,
+    "WoMeter": SwitchbotModel.METER,
+    "WoMeterPlus": SwitchbotModel.METER_PRO,
+    "WoPresence": SwitchbotModel.MOTION_SENSOR,
+    "WoBulb": SwitchbotModel.COLOR_BULB,
+    "WoCeiling": SwitchbotModel.CEILING_LIGHT,
+    "WoLock": SwitchbotModel.LOCK,
+    "WoBlindTilt": SwitchbotModel.BLIND_TILT,
+    "WoIOSensor": SwitchbotModel.IO_METER,  # Outdoor Meter
+    "WoButton": SwitchbotModel.REMOTE,  # Remote button
+    "WoLinkMini": SwitchbotModel.HUBMINI_MATTER,  # Hub Mini
+    "W1083002": SwitchbotModel.RELAY_SWITCH_1,  # Relay Switch 1
+    "W1079000": SwitchbotModel.METER_PRO,  # Meter Pro (another variant)
+    "W1102001": SwitchbotModel.STRIP_LIGHT_3,  # RGBWW Strip Light 3
+}
 
 
 class SwitchbotSupportedType(TypedDict):
@@ -383,6 +411,10 @@ def parse_advertisement_data(
     model: SwitchbotModel | None = None,
 ) -> SwitchBotAdvertisement | None:
     """Parse advertisement data."""
+    upper_mac = format_mac_upper(device.address)
+    if model is None and upper_mac in MODEL_TO_MAC_CACHE:
+        model = MODEL_TO_MAC_CACHE[upper_mac]
+
     service_data = advertisement_data.service_data
 
     _service_data = None

--- a/switchbot/adv_parser.py
+++ b/switchbot/adv_parser.py
@@ -55,32 +55,7 @@ SERVICE_DATA_ORDER = (
 )
 MFR_DATA_ORDER = (2409, 741, 89)
 
-MODEL_TO_MAC_CACHE: dict[str, SwitchbotModel] = {}
-
-# Mapping from API model names to SwitchbotModel enum values
-API_MODEL_TO_ENUM: dict[str, SwitchbotModel] = {
-    "WoHand": SwitchbotModel.BOT,
-    "WoCurtain": SwitchbotModel.CURTAIN,
-    "WoHumi": SwitchbotModel.HUMIDIFIER,
-    "WoPlug": SwitchbotModel.PLUG_MINI,
-    "WoPlugUS": SwitchbotModel.PLUG_MINI,
-    "WoContact": SwitchbotModel.CONTACT_SENSOR,
-    "WoStrip": SwitchbotModel.LIGHT_STRIP,
-    "WoSensorTH": SwitchbotModel.METER,
-    "WoMeter": SwitchbotModel.METER,
-    "WoMeterPlus": SwitchbotModel.METER_PRO,
-    "WoPresence": SwitchbotModel.MOTION_SENSOR,
-    "WoBulb": SwitchbotModel.COLOR_BULB,
-    "WoCeiling": SwitchbotModel.CEILING_LIGHT,
-    "WoLock": SwitchbotModel.LOCK,
-    "WoBlindTilt": SwitchbotModel.BLIND_TILT,
-    "WoIOSensor": SwitchbotModel.IO_METER,  # Outdoor Meter
-    "WoButton": SwitchbotModel.REMOTE,  # Remote button
-    "WoLinkMini": SwitchbotModel.HUBMINI_MATTER,  # Hub Mini
-    "W1083002": SwitchbotModel.RELAY_SWITCH_1,  # Relay Switch 1
-    "W1079000": SwitchbotModel.METER_PRO,  # Meter Pro (another variant)
-    "W1102001": SwitchbotModel.STRIP_LIGHT_3,  # RGBWW Strip Light 3
-}
+_MODEL_TO_MAC_CACHE: dict[str, SwitchbotModel] = {}
 
 
 class SwitchbotSupportedType(TypedDict):
@@ -412,8 +387,8 @@ def parse_advertisement_data(
 ) -> SwitchBotAdvertisement | None:
     """Parse advertisement data."""
     upper_mac = format_mac_upper(device.address)
-    if model is None and upper_mac in MODEL_TO_MAC_CACHE:
-        model = MODEL_TO_MAC_CACHE[upper_mac]
+    if model is None and upper_mac in _MODEL_TO_MAC_CACHE:
+        model = _MODEL_TO_MAC_CACHE[upper_mac]
 
     service_data = advertisement_data.service_data
 
@@ -502,3 +477,8 @@ def _parse_data(
             )
 
     return data
+
+
+def populate_model_to_mac_cache(mac: str, model: SwitchbotModel) -> None:
+    """Populate the model to MAC address cache."""
+    _MODEL_TO_MAC_CACHE[mac] = model

--- a/switchbot/devices/device.py
+++ b/switchbot/devices/device.py
@@ -42,6 +42,14 @@ from ..utils import format_mac_upper
 
 _LOGGER = logging.getLogger(__name__)
 
+
+def _extract_region(userinfo: dict[str, Any]) -> str:
+    """Extract region from user info, defaulting to 'us'."""
+    if "botRegion" in userinfo and userinfo["botRegion"] != "":
+        return userinfo["botRegion"]
+    return "us"
+
+
 # Mapping from API model names to SwitchbotModel enum values
 API_MODEL_TO_ENUM: dict[str, SwitchbotModel] = {
     "WoHand": SwitchbotModel.BOT,
@@ -245,10 +253,7 @@ class SwitchbotBaseDevice:
             raise SwitchbotAuthenticationError(f"Authentication failed: {err}") from err
 
         userinfo = await cls._async_get_user_info(session, auth_headers)
-        if "botRegion" in userinfo and userinfo["botRegion"] != "":
-            region = userinfo["botRegion"]
-        else:
-            region = "us"
+        region = _extract_region(userinfo)
 
         try:
             device_info = await cls.api_request(
@@ -952,10 +957,7 @@ class SwitchbotEncryptedDevice(SwitchbotDevice):
             raise SwitchbotAuthenticationError(f"Authentication failed: {err}") from err
 
         userinfo = await cls._async_get_user_info(session, auth_headers)
-        if "botRegion" in userinfo and userinfo["botRegion"] != "":
-            region = userinfo["botRegion"]
-        else:
-            region = "us"
+        region = _extract_region(userinfo)
 
         try:
             device_info = await cls.api_request(

--- a/switchbot/utils.py
+++ b/switchbot/utils.py
@@ -1,0 +1,24 @@
+"""Utility functions for switchbot."""
+
+from functools import lru_cache
+
+
+@lru_cache(maxsize=512)
+def format_mac_upper(mac: str) -> str:
+    """Format the mac address string to uppercase with colons."""
+    to_test = mac
+
+    if len(to_test) == 17 and to_test.count(":") == 5:
+        return to_test.upper()
+
+    if len(to_test) == 17 and to_test.count("-") == 5:
+        to_test = to_test.replace("-", "")
+    elif len(to_test) == 14 and to_test.count(".") == 2:
+        to_test = to_test.replace(".", "")
+
+    if len(to_test) == 12:
+        # no : included
+        return ":".join(to_test.upper()[i : i + 2] for i in range(0, 12, 2))
+
+    # Not sure how formatted, return original
+    return mac.upper()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -16,7 +16,7 @@ from switchbot.const import (
     SwitchbotAuthenticationError,
     SwitchbotModel,
 )
-from switchbot.devices.device import SwitchbotBaseDevice
+from switchbot.devices.device import SwitchbotBaseDevice, _extract_region
 
 
 @pytest.fixture
@@ -360,3 +360,20 @@ async def test_populate_model_to_mac_cache() -> None:
 
     # Clear cache after test
     _MODEL_TO_MAC_CACHE.clear()
+
+
+def test_extract_region() -> None:
+    """Test the _extract_region helper function."""
+    # Test with botRegion present and not empty
+    assert _extract_region({"botRegion": "eu", "country": "de"}) == "eu"
+    assert _extract_region({"botRegion": "us", "country": "us"}) == "us"
+    assert _extract_region({"botRegion": "jp", "country": "jp"}) == "jp"
+
+    # Test with botRegion empty string
+    assert _extract_region({"botRegion": "", "country": "de"}) == "us"
+
+    # Test with botRegion missing
+    assert _extract_region({"country": "de"}) == "us"
+
+    # Test with empty dict
+    assert _extract_region({}) == "us"

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,362 @@
+"""Tests for device.py functionality."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import aiohttp
+import pytest
+
+from switchbot import fetch_cloud_devices
+from switchbot.adv_parser import _MODEL_TO_MAC_CACHE, populate_model_to_mac_cache
+from switchbot.const import (
+    SwitchbotAccountConnectionError,
+    SwitchbotAuthenticationError,
+    SwitchbotModel,
+)
+from switchbot.devices.device import SwitchbotBaseDevice
+
+
+@pytest.fixture
+def mock_auth_response() -> dict[str, Any]:
+    """Mock authentication response."""
+    return {
+        "access_token": "test_token_123",
+        "refresh_token": "refresh_token_123",
+        "expires_in": 3600,
+    }
+
+
+@pytest.fixture
+def mock_user_info() -> dict[str, Any]:
+    """Mock user info response."""
+    return {
+        "botRegion": "us",
+        "country": "us",
+        "email": "test@example.com",
+    }
+
+
+@pytest.fixture
+def mock_device_response() -> dict[str, Any]:
+    """Mock device list response."""
+    return {
+        "Items": [
+            {
+                "device_mac": "aabbccddeeff",
+                "device_name": "Test Bot",
+                "device_detail": {
+                    "device_type": "WoHand",
+                    "version": "1.0.0",
+                },
+            },
+            {
+                "device_mac": "112233445566",
+                "device_name": "Test Curtain",
+                "device_detail": {
+                    "device_type": "WoCurtain",
+                    "version": "2.0.0",
+                },
+            },
+            {
+                "device_mac": "778899aabbcc",
+                "device_name": "Test Lock",
+                "device_detail": {
+                    "device_type": "WoLock",
+                    "version": "1.5.0",
+                },
+            },
+            {
+                "device_mac": "ddeeff001122",
+                "device_name": "Unknown Device",
+                "device_detail": {
+                    "device_type": "WoUnknown",
+                    "version": "1.0.0",
+                    "extra_field": "extra_value",
+                },
+            },
+            {
+                "device_mac": "invalid_device",
+                # Missing device_detail
+            },
+            {
+                "device_mac": "another_invalid",
+                "device_detail": {
+                    # Missing device_type
+                    "version": "1.0.0",
+                },
+            },
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_devices(
+    mock_auth_response: dict[str, Any],
+    mock_user_info: dict[str, Any],
+    mock_device_response: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test get_devices method."""
+    caplog.set_level(logging.DEBUG)
+
+    with (
+        patch.object(
+            SwitchbotBaseDevice, "_get_auth_result", return_value=mock_auth_response
+        ),
+        patch.object(
+            SwitchbotBaseDevice, "_async_get_user_info", return_value=mock_user_info
+        ),
+        patch.object(
+            SwitchbotBaseDevice, "api_request", return_value=mock_device_response
+        ) as mock_api_request,
+        patch(
+            "switchbot.devices.device.populate_model_to_mac_cache"
+        ) as mock_populate_cache,
+    ):
+        session = MagicMock(spec=aiohttp.ClientSession)
+        result = await SwitchbotBaseDevice.get_devices(
+            session, "test@example.com", "password123"
+        )
+
+        # Check that api_request was called with correct parameters
+        mock_api_request.assert_called_once_with(
+            session,
+            "wonderlabs.us",
+            "wonder/device/v3/getdevice",
+            {"required_type": "All"},
+            {"authorization": "test_token_123"},
+        )
+
+        # Check returned dictionary
+        assert len(result) == 3  # Only valid devices with known models
+        assert result["AA:BB:CC:DD:EE:FF"] == SwitchbotModel.BOT
+        assert result["11:22:33:44:55:66"] == SwitchbotModel.CURTAIN
+        assert result["77:88:99:AA:BB:CC"] == SwitchbotModel.LOCK
+
+        # Check that cache was populated
+        assert mock_populate_cache.call_count == 3
+        mock_populate_cache.assert_any_call("AA:BB:CC:DD:EE:FF", SwitchbotModel.BOT)
+        mock_populate_cache.assert_any_call("11:22:33:44:55:66", SwitchbotModel.CURTAIN)
+        mock_populate_cache.assert_any_call("77:88:99:AA:BB:CC", SwitchbotModel.LOCK)
+
+        # Check that unknown model was logged
+        assert "Unknown model WoUnknown for device DD:EE:FF:00:11:22" in caplog.text
+        assert "extra_field" in caplog.text  # Full item should be logged
+
+
+@pytest.mark.asyncio
+async def test_get_devices_with_region(
+    mock_auth_response: dict[str, Any],
+    mock_device_response: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test get_devices with different region."""
+    mock_user_info_eu = {
+        "botRegion": "eu",
+        "country": "de",
+        "email": "test@example.com",
+    }
+
+    with (
+        patch.object(
+            SwitchbotBaseDevice, "_get_auth_result", return_value=mock_auth_response
+        ),
+        patch.object(
+            SwitchbotBaseDevice, "_async_get_user_info", return_value=mock_user_info_eu
+        ),
+        patch.object(
+            SwitchbotBaseDevice, "api_request", return_value=mock_device_response
+        ) as mock_api_request,
+        patch("switchbot.devices.device.populate_model_to_mac_cache"),
+    ):
+        session = MagicMock(spec=aiohttp.ClientSession)
+        await SwitchbotBaseDevice.get_devices(
+            session, "test@example.com", "password123"
+        )
+
+        # Check that EU region was used
+        mock_api_request.assert_called_once_with(
+            session,
+            "wonderlabs.eu",
+            "wonder/device/v3/getdevice",
+            {"required_type": "All"},
+            {"authorization": "test_token_123"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_devices_no_region(
+    mock_auth_response: dict[str, Any],
+    mock_device_response: dict[str, Any],
+) -> None:
+    """Test get_devices with no region specified (defaults to us)."""
+    mock_user_info_no_region = {
+        "email": "test@example.com",
+    }
+
+    with (
+        patch.object(
+            SwitchbotBaseDevice, "_get_auth_result", return_value=mock_auth_response
+        ),
+        patch.object(
+            SwitchbotBaseDevice,
+            "_async_get_user_info",
+            return_value=mock_user_info_no_region,
+        ),
+        patch.object(
+            SwitchbotBaseDevice, "api_request", return_value=mock_device_response
+        ) as mock_api_request,
+        patch("switchbot.devices.device.populate_model_to_mac_cache"),
+    ):
+        session = MagicMock(spec=aiohttp.ClientSession)
+        await SwitchbotBaseDevice.get_devices(
+            session, "test@example.com", "password123"
+        )
+
+        # Check that default US region was used
+        mock_api_request.assert_called_once_with(
+            session,
+            "wonderlabs.us",
+            "wonder/device/v3/getdevice",
+            {"required_type": "All"},
+            {"authorization": "test_token_123"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_devices_empty_region(
+    mock_auth_response: dict[str, Any],
+    mock_device_response: dict[str, Any],
+) -> None:
+    """Test get_devices with empty region string (defaults to us)."""
+    mock_user_info_empty_region = {
+        "botRegion": "",
+        "email": "test@example.com",
+    }
+
+    with (
+        patch.object(
+            SwitchbotBaseDevice, "_get_auth_result", return_value=mock_auth_response
+        ),
+        patch.object(
+            SwitchbotBaseDevice,
+            "_async_get_user_info",
+            return_value=mock_user_info_empty_region,
+        ),
+        patch.object(
+            SwitchbotBaseDevice, "api_request", return_value=mock_device_response
+        ) as mock_api_request,
+        patch("switchbot.devices.device.populate_model_to_mac_cache"),
+    ):
+        session = MagicMock(spec=aiohttp.ClientSession)
+        await SwitchbotBaseDevice.get_devices(
+            session, "test@example.com", "password123"
+        )
+
+        # Check that default US region was used
+        mock_api_request.assert_called_once_with(
+            session,
+            "wonderlabs.us",
+            "wonder/device/v3/getdevice",
+            {"required_type": "All"},
+            {"authorization": "test_token_123"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_fetch_cloud_devices(
+    mock_auth_response: dict[str, Any],
+    mock_user_info: dict[str, Any],
+    mock_device_response: dict[str, Any],
+) -> None:
+    """Test fetch_cloud_devices wrapper function."""
+    with (
+        patch.object(
+            SwitchbotBaseDevice, "_get_auth_result", return_value=mock_auth_response
+        ),
+        patch.object(
+            SwitchbotBaseDevice, "_async_get_user_info", return_value=mock_user_info
+        ),
+        patch.object(
+            SwitchbotBaseDevice, "api_request", return_value=mock_device_response
+        ),
+        patch(
+            "switchbot.devices.device.populate_model_to_mac_cache"
+        ) as mock_populate_cache,
+    ):
+        session = MagicMock(spec=aiohttp.ClientSession)
+        result = await fetch_cloud_devices(session, "test@example.com", "password123")
+
+        # Check returned dictionary
+        assert len(result) == 3
+        assert result["AA:BB:CC:DD:EE:FF"] == SwitchbotModel.BOT
+        assert result["11:22:33:44:55:66"] == SwitchbotModel.CURTAIN
+        assert result["77:88:99:AA:BB:CC"] == SwitchbotModel.LOCK
+
+        # Check that cache was populated
+        assert mock_populate_cache.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_get_devices_authentication_error() -> None:
+    """Test get_devices with authentication error."""
+    with patch.object(
+        SwitchbotBaseDevice,
+        "_get_auth_result",
+        side_effect=Exception("Auth failed"),
+    ):
+        session = MagicMock(spec=aiohttp.ClientSession)
+        with pytest.raises(SwitchbotAuthenticationError) as exc_info:
+            await SwitchbotBaseDevice.get_devices(
+                session, "test@example.com", "wrong_password"
+            )
+        assert "Authentication failed" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_get_devices_connection_error(
+    mock_auth_response: dict[str, Any],
+    mock_user_info: dict[str, Any],
+) -> None:
+    """Test get_devices with connection error."""
+    with (
+        patch.object(
+            SwitchbotBaseDevice, "_get_auth_result", return_value=mock_auth_response
+        ),
+        patch.object(
+            SwitchbotBaseDevice, "_async_get_user_info", return_value=mock_user_info
+        ),
+        patch.object(
+            SwitchbotBaseDevice,
+            "api_request",
+            side_effect=Exception("Network error"),
+        ),
+    ):
+        session = MagicMock(spec=aiohttp.ClientSession)
+        with pytest.raises(SwitchbotAccountConnectionError) as exc_info:
+            await SwitchbotBaseDevice.get_devices(
+                session, "test@example.com", "password123"
+            )
+        assert "Failed to retrieve devices" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_populate_model_to_mac_cache() -> None:
+    """Test the populate_model_to_mac_cache helper function."""
+    # Clear the cache first
+    _MODEL_TO_MAC_CACHE.clear()
+
+    # Populate cache with test data
+    populate_model_to_mac_cache("AA:BB:CC:DD:EE:FF", SwitchbotModel.BOT)
+    populate_model_to_mac_cache("11:22:33:44:55:66", SwitchbotModel.CURTAIN)
+
+    # Check cache contents
+    assert _MODEL_TO_MAC_CACHE["AA:BB:CC:DD:EE:FF"] == SwitchbotModel.BOT
+    assert _MODEL_TO_MAC_CACHE["11:22:33:44:55:66"] == SwitchbotModel.CURTAIN
+    assert len(_MODEL_TO_MAC_CACHE) == 2
+
+    # Clear cache after test
+    _MODEL_TO_MAC_CACHE.clear()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,41 @@
+"""Tests for utils.py functionality."""
+
+from __future__ import annotations
+
+from switchbot.utils import format_mac_upper
+
+
+def test_format_mac_upper() -> None:
+    """Test the format_mac_upper utility function."""
+    # Test already formatted with colons (lowercase)
+    assert format_mac_upper("aa:bb:cc:dd:ee:ff") == "AA:BB:CC:DD:EE:FF"
+
+    # Test already formatted with colons (uppercase)
+    assert format_mac_upper("AA:BB:CC:DD:EE:FF") == "AA:BB:CC:DD:EE:FF"
+
+    # Test with dashes
+    assert format_mac_upper("aa-bb-cc-dd-ee-ff") == "AA:BB:CC:DD:EE:FF"
+    assert format_mac_upper("AA-BB-CC-DD-EE-FF") == "AA:BB:CC:DD:EE:FF"
+
+    # Test with dots (Cisco format)
+    assert format_mac_upper("aabb.ccdd.eeff") == "AA:BB:CC:DD:EE:FF"
+    assert format_mac_upper("AABB.CCDD.EEFF") == "AA:BB:CC:DD:EE:FF"
+
+    # Test without separators
+    assert format_mac_upper("aabbccddeeff") == "AA:BB:CC:DD:EE:FF"
+    assert format_mac_upper("AABBCCDDEEFF") == "AA:BB:CC:DD:EE:FF"
+
+    # Test mixed case without separators
+    assert format_mac_upper("AaBbCcDdEeFf") == "AA:BB:CC:DD:EE:FF"
+
+    # Test invalid formats (should return original in uppercase)
+    assert format_mac_upper("invalid") == "INVALID"
+    assert format_mac_upper("aa:bb:cc") == "AA:BB:CC"  # Too short
+    assert (
+        format_mac_upper("aa:bb:cc:dd:ee:ff:gg") == "AA:BB:CC:DD:EE:FF:GG"
+    )  # Too long
+
+    # Test edge cases
+    assert format_mac_upper("") == ""
+    assert format_mac_upper("123456789ABC") == "12:34:56:78:9A:BC"
+    assert format_mac_upper("12:34:56:78:9a:bc") == "12:34:56:78:9A:BC"


### PR DESCRIPTION
Fixes #284

## Summary

This PR adds support for discovering Switchbot devices when the Bluetooth adapter is performing passive scans by fetching device information from the Switchbot cloud API and caching MAC address to model mappings.

## Problem

When a Bluetooth adapter is configured for passive scanning (not sending scan requests), it only receives passive advertisements from devices. These passive advertisements from Switchbot devices contain only manufacturer data without service data, making it impossible to identify the device model from the advertisement alone. This causes discovery to fail when the adapter is in passive scanning mode.

## Solution

Added a new `fetch_cloud_devices()` function that:
1. Authenticates with the Switchbot cloud API using existing credentials
2. Retrieves all devices associated with the account
3. Populates an internal MAC address to model cache
4. Returns a dictionary of discovered devices for reference

Once the cache is populated, the advertisement parser can identify passive devices by their MAC address and correctly decode their advertisements.

## Usage

```python
import asyncio
import aiohttp
from switchbot import fetch_cloud_devices

async def discover_devices():
    async with aiohttp.ClientSession() as session:
        # Call once before starting discovery
        # This populates the internal cache with your devices
        devices = await fetch_cloud_devices(
            session,
            username="your_email@example.com", 
            password="your_password"
        )
        
        print(f"Found {len(devices)} devices in cloud")
        
        # Now proceed with normal BLE discovery
        # The advertisement parser will automatically use the cache
        # to identify devices in passive mode
        # ... your existing discovery code ...
```

## How It Works

1. **Before this PR**: When adapter is in passive scan mode, advertisements couldn't be decoded
   ```python
   # Bluetooth adapter in passive scan mode receives limited advertisement data
   # (no active scan requests sent, only passive advertisements received)
   result = parse_advertisement_data(device, adv_data)
   # result would be None - device not recognized
   ```

2. **After this PR**: Same passive scan advertisements are now decoded
   ```python
   # First, fetch cloud devices (done once at startup)
   await fetch_cloud_devices(session, username, password)
   
   # Now passive scan advertisements can be decoded
   result = parse_advertisement_data(device, adv_data)
   # result contains full device information!
   ```

## Implementation Details

### New Components

- **`switchbot/utils.py`**: Added `format_mac_upper()` to normalize MAC addresses
- **`switchbot/devices/device.py`**: 
  - Modified `get_devices()` to return `dict[str, SwitchbotModel]` with formatted MACs
  - Added `fetch_cloud_devices()` as the public API
  - Added `_extract_region()` helper to reduce code duplication
- **`switchbot/adv_parser.py`**:
  - Added `_MODEL_TO_MAC_CACHE` for storing MAC to model mappings
  - Added `populate_model_to_mac_cache()` helper function
  - Parser now checks cache when model cannot be determined from advertisement

### API Model Mappings

Added mappings for all known Switchbot device types:
- WoHand → BOT
- WoCurtain → CURTAIN  
- WoLock → LOCK
- WoBulb → COLOR_BULB
- WoStrip → LIGHT_STRIP
- WoMeterPlus → METER_PRO
- And many more...

Unknown models are logged with their full payload to help identify new devices.

## Testing

Added comprehensive test coverage:
- `tests/test_device.py`: Tests for `get_devices()` and `fetch_cloud_devices()`
- `tests/test_utils.py`: Tests for `format_mac_upper()`
- `tests/test_adv_parser.py`: Tests showing cache enables passive device discovery

## Benefits

- Devices are now discoverable when Bluetooth adapter is in passive scan mode
- Reduces Bluetooth traffic (no active scan requests needed)
- Better for environments with many Bluetooth devices
- Automatic region detection (US, EU, JP, etc.)
- Logs unknown device models for future support

## Breaking Changes

None. This is purely additive - existing code continues to work as before.

## Example Use Case

For Home Assistant or other integrations:
```python
from switchbot import fetch_cloud_devices
from switchbot.const import (
    SwitchbotAccountConnectionError,
    SwitchbotAuthenticationError,
)

async def setup_switchbot_discovery(username, password):
    """Setup Switchbot discovery with cloud device fetching."""
    async with aiohttp.ClientSession() as session:
        try:
            # Fetch and cache cloud devices once at startup
            cloud_devices = await fetch_cloud_devices(session, username, password)
            _LOGGER.info(f"Cached {len(cloud_devices)} Switchbot devices from cloud")
        except SwitchbotAuthenticationError as e:
            _LOGGER.warning(f"Invalid Switchbot credentials: {e}")
            # Discovery will still work for active devices
        except SwitchbotAccountConnectionError as e:
            _LOGGER.warning(f"Could not connect to Switchbot cloud: {e}")
            # Discovery will still work for active devices
        
        # Continue with normal BLE discovery
        # Passive devices will now be recognized automatically
        await start_ble_discovery()
```

## Notes

- Cloud fetch is optional - discovery still works without it for actively advertising devices
- Cache persists for the lifetime of the process
- Credentials are only used for the initial cloud fetch, not stored
- Works with all regions (automatically detects US, EU, JP, etc.)