### PR TITLE
Fix ENCRYPTION_KEY var in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ from switchbot.const import SwitchbotModel
 
 BLE_MAC="XX:XX:XX:XX:XX:XX" # The MAC of your lock
 KEY_ID="XX" # The key-ID of your encryption-key for your lock
-ENC_KEY="XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" # The encryption-key with key-ID "XX"
+ENCRYPTION_KEY="XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" # The encryption-key with key-ID "XX"
 LOCK_MODEL=SwitchbotModel.LOCK_PRO # Your lock model (here we use the Lock-Pro)
 
 
@@ -55,7 +55,7 @@ from switchbot.const import SwitchbotModel
 
 BLE_MAC="XX:XX:XX:XX:XX:XX" # The MAC of your lock
 KEY_ID="XX" # The key-ID of your encryption-key for your lock
-ENC_KEY="XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" # The encryption-key with key-ID "XX"
+ENCRYPTION_KEY="XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" # The encryption-key with key-ID "XX"
 LOCK_MODEL=SwitchbotModel.LOCK_PRO # Your lock model (here we use the Lock-Pro)
 
 


### PR DESCRIPTION
Fixes var name being unabbreviated when defined.