### PR TITLE
Add .gitattributes to enforce consistent line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Enforce LF line endings for all text files
+* text=auto eol=lf
+
+# Explicitly declare Python files as text
+*.py text eol=lf


### PR DESCRIPTION
Add a .gitattributes file to enforce consistent line endings across different environments (e.g., Windows and Unix).

This helps prevent unintended diffs and issues caused by CRLF/LF mismatches when collaborating across platforms.