### PR TITLE
ci: auto-close PRs opened from a fork's default branch

### DIFF
--- a/.github/workflows/auto-close-default-branch-prs.yml
+++ b/.github/workflows/auto-close-default-branch-prs.yml
@@ -1,0 +1,72 @@
+name: Close PR From Fork Default Branch
+
+on:
+  # pull_request_target is required so we have permission to comment and close PRs from forks.
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  close:
+    name: Close PR opened from fork's default branch
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+      && github.event.pull_request.head.ref == github.event.repository.default_branch
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+            const author = context.payload.pull_request.user.login;
+            const defaultBranch = context.payload.repository.default_branch;
+            const headRepo = context.payload.pull_request.head.repo.full_name;
+
+            const body = [
+              `Hi @${author}, thanks for opening a pull request! :tada:`,
+              ``,
+              `It looks like this PR was opened from the \`${defaultBranch}\` branch of your fork (\`${headRepo}\`), which is the same name as this repository's default branch. Working directly on \`${defaultBranch}\` in your fork causes a few problems:`,
+              ``,
+              `- Your fork's \`${defaultBranch}\` branch will permanently diverge from \`${owner}/${repo}:${defaultBranch}\`, making it hard to keep your fork up to date.`,
+              `- Any additional commits you push to \`${defaultBranch}\` will be added to this PR, so you can't easily work on multiple changes at once.`,
+              `- Pushing maintainer fixes to your branch is awkward, since it means committing directly to your fork's default branch.`,
+              `- It makes local collaboration painful — \`${defaultBranch}\` in a checkout becomes ambiguous between upstream and your fork, and maintainers end up with naming collisions when fetching your branch.`,
+              ``,
+              `Please re-open this as a new PR from a dedicated feature branch. The usual flow looks like:`,
+              ``,
+              `\`\`\`bash`,
+              `# Make sure your fork's ${defaultBranch} is up to date with upstream`,
+              `git remote add upstream https://github.com/${owner}/${repo}.git  # if you haven't already`,
+              `git fetch upstream`,
+              `git checkout ${defaultBranch}`,
+              `git reset --hard upstream/${defaultBranch}`,
+              `git push --force-with-lease origin ${defaultBranch}`,
+              ``,
+              `# Create a new branch for your change and cherry-pick / re-apply your commits there`,
+              `git checkout -b my-feature-branch upstream/${defaultBranch}`,
+              `# ...re-apply your changes, then:`,
+              `git push origin my-feature-branch`,
+              `\`\`\``,
+              ``,
+              `Then open a new pull request from \`my-feature-branch\` into \`${owner}/${repo}:${defaultBranch}\`.`,
+              ``,
+              `Closing this PR for now — sorry for the friction, and thanks again for contributing! :heart:`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: prNumber,
+              body,
+            });
+
+            await github.rest.pulls.update({
+              owner,
+              repo,
+              pull_number: prNumber,
+              state: 'closed',
+            });


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that auto-closes pull requests opened from a fork's default branch (the PR's head branch shares the upstream default-branch name) and posts a friendly comment explaining the problem and how to move the work to a feature branch.

We've seen this come up several times recently (see e.g. #456, #430). When a contributor PRs from their fork's \`master\`:

- Their fork's \`master\` permanently diverges from \`sblibs/pySwitchbot:master\`, making it hard to keep the fork in sync.
- Any additional commits pushed to \`master\` on the fork get tacked onto the open PR, so the contributor can't work on multiple changes in parallel.
- Pushing maintainer fixes to the PR is awkward, since it means committing directly to the contributor's default branch.
- Local checkouts get ambiguous \`master\` names between upstream and the fork.

## How it works

- Triggers on \`pull_request_target\` (\`opened\`, \`reopened\`) — runs in the base-repo context so it has write permissions, but **does not check out PR code**, so no untrusted code executes.
- Fires only when the PR head is in a fork (\`head.repo.full_name != base.repo.full_name\`) **and** \`head.ref == repository.default_branch\`. Internal branches and PRs from feature branches are untouched, even if a feature branch happens to be named \`master\`.
- Uses \`actions/github-script\` pinned to a full SHA (security best practice for \`pull_request_target\`).

Pattern adopted from esphome/esphome#15957.

## Test plan

- [ ] Workflow lints (\`actionlint\` if available; otherwise GitHub's built-in YAML validation on push).
- [ ] After merge, open a test PR from a fork's default branch and confirm:
  - [ ] The friendly comment is posted.
  - [ ] The PR is closed.
  - [ ] PRs from feature branches are not affected.