### PR TITLE
Add SwitchbotKeypad device class for classic Keypad

### DIFF
--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -50,6 +50,7 @@ from .devices.device import (
 from .devices.evaporative_humidifier import SwitchbotEvaporativeHumidifier
 from .devices.fan import SwitchbotFan, SwitchbotStandingFan
 from .devices.humidifier import SwitchbotHumidifier
+from .devices.keypad import SwitchbotKeypad
 from .devices.keypad_vision import SwitchbotKeypadVision
 from .devices.light_strip import (
     SwitchbotCandleWarmerLamp,
@@ -112,6 +113,7 @@ __all__ = [
     "SwitchbotFan",
     "SwitchbotGarageDoorOpener",
     "SwitchbotHumidifier",
+    "SwitchbotKeypad",
     "SwitchbotKeypadVision",
     "SwitchbotLightStrip",
     "SwitchbotLock",

--- a/switchbot/devices/keypad.py
+++ b/switchbot/devices/keypad.py
@@ -6,4 +6,8 @@ from .device import SwitchbotDevice
 
 
 class SwitchbotKeypad(SwitchbotDevice):
-    """Representation of a Switchbot Keypad device."""
+    """Representation of a Switchbot Keypad (WoKeypad) device.
+
+    Passive BLE-only — no commands. Battery and attempt_state come from
+    advertisement parsing in adv_parsers/keypad.py.
+    """

--- a/switchbot/devices/keypad.py
+++ b/switchbot/devices/keypad.py
@@ -1,1 +1,9 @@
+"""Keypad device handling."""
+
 from __future__ import annotations
+
+from .device import SwitchbotDevice
+
+
+class SwitchbotKeypad(SwitchbotDevice):
+    """Representation of a Switchbot Keypad device."""

--- a/switchbot/devices/keypad.py
+++ b/switchbot/devices/keypad.py
@@ -6,9 +6,13 @@ from .device import SwitchbotDevice
 
 
 class SwitchbotKeypad(SwitchbotDevice):
-    """
-    Representation of a Switchbot Keypad (WoKeypad) device.
+    """Representation of a Switchbot Keypad (WoKeypad) device.
 
     Passive BLE-only — no commands. Battery and attempt_state come from
     advertisement parsing in adv_parsers/keypad.py.
     """
+
+    @property
+    def attempt_state(self) -> int | None:
+        """Return the last attempt state from advertisement data."""
+        return self._get_adv_value("attempt_state")

--- a/switchbot/devices/keypad.py
+++ b/switchbot/devices/keypad.py
@@ -6,7 +6,8 @@ from .device import SwitchbotDevice
 
 
 class SwitchbotKeypad(SwitchbotDevice):
-    """Representation of a Switchbot Keypad (WoKeypad) device.
+    """
+    Representation of a Switchbot Keypad (WoKeypad) device.
 
     Passive BLE-only — no commands. Battery and attempt_state come from
     advertisement parsing in adv_parsers/keypad.py.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,8 +1,6 @@
 from dataclasses import dataclass
 
-from bleak.backends.device import BLEDevice
-
-from switchbot import SwitchBotAdvertisement, SwitchbotModel
+from switchbot import SwitchbotModel
 
 
 @dataclass
@@ -13,29 +11,6 @@ class AdvTestCase:
     model: str | bytes
     modelFriendlyName: str
     modelName: SwitchbotModel
-
-
-def make_advertisement_data(
-    ble_device: BLEDevice, adv_info: AdvTestCase, init_data: dict | None = None
-) -> SwitchBotAdvertisement:
-    """Build a SwitchBotAdvertisement from an AdvTestCase fixture."""
-    if init_data is None:
-        init_data = {}
-
-    return SwitchBotAdvertisement(
-        address="aa:bb:cc:dd:ee:ff",
-        data={
-            "rawAdvData": adv_info.service_data,
-            "data": adv_info.data | init_data,
-            "isEncrypted": False,
-            "model": adv_info.model,
-            "modelFriendlyName": adv_info.modelFriendlyName,
-            "modelName": adv_info.modelName,
-        },
-        device=ble_device,
-        rssi=-80,
-        active=True,
-    )
 
 
 KEYPAD_INFO = AdvTestCase(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,6 +13,19 @@ class AdvTestCase:
     modelName: SwitchbotModel
 
 
+KEYPAD_INFO = AdvTestCase(
+    b"\xeb\x13\x02\xe6#\x0f\x8fd\x00\x00\x00\x00",
+    b"y\x00d",
+    {
+        "battery": 100,
+        "attempt_state": 143,
+    },
+    "y",
+    "Keypad",
+    SwitchbotModel.KEYPAD,
+)
+
+
 STRIP_LIGHT_3_INFO = AdvTestCase(
     b'\xc0N0\xe0U\x9a\x85\x9e"\xd0\x00\x00\x00\x00\x00\x00\x12\x91\x00',
     b"\x00\x00\x00\x00\x10\xd0\xb1",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 
-from switchbot import SwitchbotModel
+from bleak.backends.device import BLEDevice
+
+from switchbot import SwitchBotAdvertisement, SwitchbotModel
 
 
 @dataclass
@@ -11,6 +13,29 @@ class AdvTestCase:
     model: str | bytes
     modelFriendlyName: str
     modelName: SwitchbotModel
+
+
+def make_advertisement_data(
+    ble_device: BLEDevice, adv_info: AdvTestCase, init_data: dict | None = None
+) -> SwitchBotAdvertisement:
+    """Build a SwitchBotAdvertisement from an AdvTestCase fixture."""
+    if init_data is None:
+        init_data = {}
+
+    return SwitchBotAdvertisement(
+        address="aa:bb:cc:dd:ee:ff",
+        data={
+            "rawAdvData": adv_info.service_data,
+            "data": adv_info.data | init_data,
+            "isEncrypted": False,
+            "model": adv_info.model,
+            "modelFriendlyName": adv_info.modelFriendlyName,
+            "modelName": adv_info.modelName,
+        },
+        device=ble_device,
+        rssi=-80,
+        active=True,
+    )
 
 
 KEYPAD_INFO = AdvTestCase(

--- a/tests/test_keypad.py
+++ b/tests/test_keypad.py
@@ -7,7 +7,9 @@ from . import KEYPAD_INFO
 from .test_adv_parser import AdvTestCase, generate_ble_device
 
 
-def make_advertisement_data(ble_device, adv_info: AdvTestCase, init_data: dict | None = None):
+def make_advertisement_data(
+    ble_device, adv_info: AdvTestCase, init_data: dict | None = None
+):
     """Set advertisement data with defaults."""
     if init_data is None:
         init_data = {}

--- a/tests/test_keypad.py
+++ b/tests/test_keypad.py
@@ -56,3 +56,4 @@ def test_keypad_advertisement_battery_none_when_no_data() -> None:
     device.update_from_advertisement(advertisement)
 
     assert device.get_battery_percent() is None
+    assert device.parsed_data["attempt_state"] is None

--- a/tests/test_keypad.py
+++ b/tests/test_keypad.py
@@ -1,6 +1,6 @@
 """Test keypad device advertisement parsing."""
 
-from switchbot import SwitchBotAdvertisement, SwitchbotKeypad
+from switchbot import SwitchbotKeypad
 from switchbot.models import SwitchBotAdvertisement
 
 from . import KEYPAD_INFO

--- a/tests/test_keypad.py
+++ b/tests/test_keypad.py
@@ -1,60 +1,52 @@
 """Test keypad device advertisement parsing."""
 
-from switchbot import SwitchbotKeypad
-from switchbot.models import SwitchBotAdvertisement
+from switchbot import SwitchbotKeypad, SwitchbotModel
+from switchbot.adv_parser import parse_advertisement_data
 
-from . import KEYPAD_INFO
-from .test_adv_parser import AdvTestCase, generate_ble_device
-
-
-def make_advertisement_data(
-    ble_device, adv_info: AdvTestCase, init_data: dict | None = None
-):
-    """Set advertisement data with defaults."""
-    if init_data is None:
-        init_data = {}
-
-    return SwitchBotAdvertisement(
-        address="aa:bb:cc:dd:ee:ff",
-        data={
-            "rawAdvData": adv_info.service_data,
-            "data": adv_info.data | init_data,
-            "isEncrypted": False,
-            "model": adv_info.model,
-            "modelFriendlyName": adv_info.modelFriendlyName,
-            "modelName": adv_info.modelName,
-        }
-        | init_data,
-        device=ble_device,
-        rssi=-80,
-        active=True,
-    )
+from . import KEYPAD_INFO, make_advertisement_data
+from .test_adv_parser import generate_advertisement_data, generate_ble_device
 
 
 def test_keypad_advertisement_battery() -> None:
-    """Test that battery is parsed from keypad advertisement."""
+    """Test that battery is parsed from keypad advertisement data."""
     ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
+    adv_data = generate_advertisement_data(
+        manufacturer_data={2409: KEYPAD_INFO.manufacturer_data},
+        service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": KEYPAD_INFO.service_data},
+        rssi=-80,
+    )
+    advertisement = parse_advertisement_data(ble_device, adv_data, SwitchbotModel.KEYPAD)
     device = SwitchbotKeypad(ble_device)
-    device.update_from_advertisement(make_advertisement_data(ble_device, KEYPAD_INFO))
+    device.update_from_advertisement(advertisement)
 
-    assert device.parsed_data["battery"] == 100
+    assert device.get_battery_percent() == 100
 
 
 def test_keypad_advertisement_attempt_state() -> None:
-    """Test that attempt_state is parsed from keypad advertisement."""
+    """Test that attempt_state is parsed from keypad advertisement data."""
     ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
+    adv_data = generate_advertisement_data(
+        manufacturer_data={2409: KEYPAD_INFO.manufacturer_data},
+        service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": KEYPAD_INFO.service_data},
+        rssi=-80,
+    )
+    advertisement = parse_advertisement_data(ble_device, adv_data, SwitchbotModel.KEYPAD)
     device = SwitchbotKeypad(ble_device)
-    device.update_from_advertisement(make_advertisement_data(ble_device, KEYPAD_INFO))
+    device.update_from_advertisement(advertisement)
 
     assert device.parsed_data["attempt_state"] == 143
 
 
-def test_keypad_advertisement_battery_none() -> None:
+def test_keypad_advertisement_battery_none_when_no_data() -> None:
     """Test that battery is None when advertisement data is missing."""
     ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
-    device = SwitchbotKeypad(ble_device)
-    device.update_from_advertisement(
-        make_advertisement_data(ble_device, KEYPAD_INFO, {"battery": None})
+    adv_data = generate_advertisement_data(
+        manufacturer_data={},
+        service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": KEYPAD_INFO.service_data},
+        rssi=-80,
     )
+    advertisement = parse_advertisement_data(ble_device, adv_data, SwitchbotModel.KEYPAD)
+    device = SwitchbotKeypad(ble_device)
+    device.update_from_advertisement(advertisement)
 
-    assert device.parsed_data["battery"] is None
+    assert device.get_battery_percent() is None

--- a/tests/test_keypad.py
+++ b/tests/test_keypad.py
@@ -1,0 +1,58 @@
+"""Test keypad device advertisement parsing."""
+
+from switchbot import SwitchBotAdvertisement, SwitchbotKeypad
+from switchbot.models import SwitchBotAdvertisement
+
+from . import KEYPAD_INFO
+from .test_adv_parser import AdvTestCase, generate_ble_device
+
+
+def make_advertisement_data(ble_device, adv_info: AdvTestCase, init_data: dict | None = None):
+    """Set advertisement data with defaults."""
+    if init_data is None:
+        init_data = {}
+
+    return SwitchBotAdvertisement(
+        address="aa:bb:cc:dd:ee:ff",
+        data={
+            "rawAdvData": adv_info.service_data,
+            "data": adv_info.data | init_data,
+            "isEncrypted": False,
+            "model": adv_info.model,
+            "modelFriendlyName": adv_info.modelFriendlyName,
+            "modelName": adv_info.modelName,
+        }
+        | init_data,
+        device=ble_device,
+        rssi=-80,
+        active=True,
+    )
+
+
+def test_keypad_advertisement_battery() -> None:
+    """Test that battery is parsed from keypad advertisement."""
+    ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
+    device = SwitchbotKeypad(ble_device)
+    device.update_from_advertisement(make_advertisement_data(ble_device, KEYPAD_INFO))
+
+    assert device.parsed_data["battery"] == 100
+
+
+def test_keypad_advertisement_attempt_state() -> None:
+    """Test that attempt_state is parsed from keypad advertisement."""
+    ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
+    device = SwitchbotKeypad(ble_device)
+    device.update_from_advertisement(make_advertisement_data(ble_device, KEYPAD_INFO))
+
+    assert device.parsed_data["attempt_state"] == 143
+
+
+def test_keypad_advertisement_battery_none() -> None:
+    """Test that battery is None when advertisement data is missing."""
+    ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
+    device = SwitchbotKeypad(ble_device)
+    device.update_from_advertisement(
+        make_advertisement_data(ble_device, KEYPAD_INFO, {"battery": None})
+    )
+
+    assert device.parsed_data["battery"] is None

--- a/tests/test_keypad.py
+++ b/tests/test_keypad.py
@@ -38,7 +38,7 @@ def test_keypad_advertisement_attempt_state() -> None:
     device = SwitchbotKeypad(ble_device)
     device.update_from_advertisement(advertisement)
 
-    assert device.parsed_data["attempt_state"] == 143
+    assert device.attempt_state == 143
 
 
 def test_keypad_advertisement_battery_none_when_no_data() -> None:
@@ -56,4 +56,4 @@ def test_keypad_advertisement_battery_none_when_no_data() -> None:
     device.update_from_advertisement(advertisement)
 
     assert device.get_battery_percent() is None
-    assert device.parsed_data["attempt_state"] is None
+    assert device.attempt_state is None

--- a/tests/test_keypad.py
+++ b/tests/test_keypad.py
@@ -3,7 +3,7 @@
 from switchbot import SwitchbotKeypad, SwitchbotModel
 from switchbot.adv_parser import parse_advertisement_data
 
-from . import KEYPAD_INFO, make_advertisement_data
+from . import KEYPAD_INFO
 from .test_adv_parser import generate_advertisement_data, generate_ble_device
 
 
@@ -15,7 +15,9 @@ def test_keypad_advertisement_battery() -> None:
         service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": KEYPAD_INFO.service_data},
         rssi=-80,
     )
-    advertisement = parse_advertisement_data(ble_device, adv_data, SwitchbotModel.KEYPAD)
+    advertisement = parse_advertisement_data(
+        ble_device, adv_data, SwitchbotModel.KEYPAD
+    )
     device = SwitchbotKeypad(ble_device)
     device.update_from_advertisement(advertisement)
 
@@ -30,7 +32,9 @@ def test_keypad_advertisement_attempt_state() -> None:
         service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": KEYPAD_INFO.service_data},
         rssi=-80,
     )
-    advertisement = parse_advertisement_data(ble_device, adv_data, SwitchbotModel.KEYPAD)
+    advertisement = parse_advertisement_data(
+        ble_device, adv_data, SwitchbotModel.KEYPAD
+    )
     device = SwitchbotKeypad(ble_device)
     device.update_from_advertisement(advertisement)
 
@@ -45,7 +49,9 @@ def test_keypad_advertisement_battery_none_when_no_data() -> None:
         service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": KEYPAD_INFO.service_data},
         rssi=-80,
     )
-    advertisement = parse_advertisement_data(ble_device, adv_data, SwitchbotModel.KEYPAD)
+    advertisement = parse_advertisement_data(
+        ble_device, adv_data, SwitchbotModel.KEYPAD
+    )
     device = SwitchbotKeypad(ble_device)
     device.update_from_advertisement(advertisement)
 

--- a/tests/test_keypad_vision.py
+++ b/tests/test_keypad_vision.py
@@ -3,16 +3,14 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from bleak.backends.device import BLEDevice
 
-from switchbot import SwitchBotAdvertisement
 from switchbot.devices.device import SwitchbotEncryptedDevice
 from switchbot.devices.keypad_vision import (
     COMMAND_GET_PASSWORD_COUNT,
     SwitchbotKeypadVision,
 )
 
-from . import KEYPAD_VISION_INFO, KEYPAD_VISION_PRO_INFO
+from . import KEYPAD_VISION_INFO, KEYPAD_VISION_PRO_INFO, make_advertisement_data
 from .test_adv_parser import AdvTestCase, generate_ble_device
 
 
@@ -32,30 +30,6 @@ def create_device_for_command_testing(
         make_advertisement_data(ble_device, adv_info, init_data)
     )
     return device
-
-
-def make_advertisement_data(
-    ble_device: BLEDevice, adv_info: AdvTestCase, init_data: dict | None = None
-):
-    """Set advertisement data with defaults."""
-    if init_data is None:
-        init_data = {}
-
-    return SwitchBotAdvertisement(
-        address="aa:bb:cc:dd:ee:ff",
-        data={
-            "rawAdvData": adv_info.service_data,
-            "data": adv_info.data | init_data,
-            "isEncrypted": False,
-            "model": adv_info.model,
-            "modelFriendlyName": adv_info.modelFriendlyName,
-            "modelName": adv_info.modelName,
-        }
-        | init_data,
-        device=ble_device,
-        rssi=-80,
-        active=True,
-    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_keypad_vision.py
+++ b/tests/test_keypad_vision.py
@@ -3,14 +3,16 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from bleak.backends.device import BLEDevice
 
+from switchbot import SwitchBotAdvertisement
 from switchbot.devices.device import SwitchbotEncryptedDevice
 from switchbot.devices.keypad_vision import (
     COMMAND_GET_PASSWORD_COUNT,
     SwitchbotKeypadVision,
 )
 
-from . import KEYPAD_VISION_INFO, KEYPAD_VISION_PRO_INFO, make_advertisement_data
+from . import KEYPAD_VISION_INFO, KEYPAD_VISION_PRO_INFO
 from .test_adv_parser import AdvTestCase, generate_ble_device
 
 
@@ -30,6 +32,30 @@ def create_device_for_command_testing(
         make_advertisement_data(ble_device, adv_info, init_data)
     )
     return device
+
+
+def make_advertisement_data(
+    ble_device: BLEDevice, adv_info: AdvTestCase, init_data: dict | None = None
+):
+    """Set advertisement data with defaults."""
+    if init_data is None:
+        init_data = {}
+
+    return SwitchBotAdvertisement(
+        address="aa:bb:cc:dd:ee:ff",
+        data={
+            "rawAdvData": adv_info.service_data,
+            "data": adv_info.data | init_data,
+            "isEncrypted": False,
+            "model": adv_info.model,
+            "modelFriendlyName": adv_info.modelFriendlyName,
+            "modelName": adv_info.modelName,
+        }
+        | init_data,
+        device=ble_device,
+        rssi=-80,
+        active=True,
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Adds support for SwitchBot Keypad (WoKeypad) — exposes battery level and attempt_state from BLE advertisements.
https://eu.switch-bot.com/products/switchbot-keypad

**Tested on a real device** — scanner confirmed `battery: 100` and `attempt_state` parsed correctly from live BLE advertisement data.

## Summary

The classic SwitchBot Keypad (WoKeypad) is a passive BLE-only device used to unlock doors paired with SwitchBot Lock. The advertisement parser (`adv_parsers/keypad.py`) already parses `battery` and `attempt_state` from BLE advertisements, and `SwitchbotModel.KEYPAD` is already defined, but no device class existed.

## Changes

- Add `SwitchbotKeypad` device class in `devices/keypad.py`, extending `SwitchbotDevice` (passive-only, no BLE commands)
- Export `SwitchbotKeypad` from `switchbot/__init__.py`
- Add `KEYPAD_INFO` test fixture in `tests/__init__.py`
- Add `tests/test_keypad.py` verifying battery and attempt_state are correctly parsed from advertisement data

## Test results

All 3 unit tests pass. Verified against real WoKeypad hardware — advertisement data parsed correctly.