### PR TITLE
fix: leak detector with passive scanning

### DIFF
--- a/switchbot/adv_parsers/leak.py
+++ b/switchbot/adv_parsers/leak.py
@@ -3,7 +3,7 @@
 
 def process_leak(data: bytes | None, mfr_data: bytes | None) -> dict[str, bool | int]:
     """Process SwitchBot Water Leak Detector advertisement data."""
-    if data is None or len(data) < 3 or mfr_data is None or len(mfr_data) < 9:
+    if mfr_data is None or len(mfr_data) < 9:
         return {}
 
     water_leak_detected = None

--- a/tests/test_adv_parser.py
+++ b/tests/test_adv_parser.py
@@ -1513,9 +1513,16 @@ def test_leak_passive():
     assert result == SwitchBotAdvertisement(
         address="aa:bb:cc:dd:ee:ff",
         data={
-            "data": {},
+            "data": {
+                "leak": False,
+                "tampered": False,
+                "battery": 78,
+                "low_battery": False,
+            },
             "isEncrypted": False,
             "model": "&",
+            "modelFriendlyName": "Leak Detector",
+            "modelName": SwitchbotModel.LEAK,
             "rawAdvData": None,
         },
         device=ble_device,


### PR DESCRIPTION
Remove unnecessary check for data (containing service data). Service data is absent in passive scans. Later parsing code only uses mfr_data anyway so this check does not appear necessary.

I am not sure why the ckeck was there. The presence of a test suggests that it was intentional as if the sensor did not send valid mfr_data in passive scans and mfr_data should only be parsed in an active scan.

However my Switchbot leak detectors (bought July 2025 and April 2026) do send usable battery and leak bits in mfr_data also in passive scans so this check seems unnecessary and prevents me from using parse_advertisement_data in my setup.