### PR TITLE
fix: Infer TRV idle state when target temperature is reached with 0.5°C hysteresis

### DIFF
--- a/switchbot/devices/smart_thermostat_radiator.py
+++ b/switchbot/devices/smart_thermostat_radiator.py
@@ -190,19 +190,19 @@ class SwitchbotSmartThermostatRadiator(
         return self._get_adv_value("target_temperature")
 
 
-def get_action(self) -> ClimateAction:
-    """Return current action from cache."""
-    if not self.is_on():
-        return ClimateAction.OFF
+    def get_action(self) -> ClimateAction:
+        """Return current action from cache."""
+        if not self.is_on():
+            return ClimateAction.OFF
 
-    current_temp = self.get_current_temperature()
-    target_temp = self.get_target_temperature()
+        current_temp = self.get_current_temperature()
+        target_temp = self.get_target_temperature()
 
-    if (
-        current_temp is not None
-        and target_temp is not None
-        and current_temp >= (target_temp + 0.5)
-    ):
-        return ClimateAction.IDLE
+        if (
+            current_temp is not None
+            and target_temp is not None
+            and current_temp >= (target_temp + 0.5)
+        ):
+            return ClimateAction.IDLE
 
-    return ClimateAction.HEATING
+        return ClimateAction.HEATING

--- a/switchbot/devices/smart_thermostat_radiator.py
+++ b/switchbot/devices/smart_thermostat_radiator.py
@@ -189,8 +189,20 @@ class SwitchbotSmartThermostatRadiator(
         """Return the target temperature."""
         return self._get_adv_value("target_temperature")
 
-    def get_action(self) -> ClimateAction:
-        """Return current action from cache."""
-        if not self.is_on():
-            return ClimateAction.OFF
-        return ClimateAction.HEATING
+
+def get_action(self) -> ClimateAction:
+    """Return current action from cache."""
+    if not self.is_on():
+        return ClimateAction.OFF
+
+    current_temp = self.get_current_temperature()
+    target_temp = self.get_target_temperature()
+
+    if (
+        current_temp is not None
+        and target_temp is not None
+        and current_temp >= (target_temp + 0.5)
+    ):
+        return ClimateAction.IDLE
+
+    return ClimateAction.HEATING

--- a/switchbot/devices/smart_thermostat_radiator.py
+++ b/switchbot/devices/smart_thermostat_radiator.py
@@ -189,7 +189,6 @@ class SwitchbotSmartThermostatRadiator(
         """Return the target temperature."""
         return self._get_adv_value("target_temperature")
 
-
     def get_action(self) -> ClimateAction:
         """Return current action from cache."""
         if not self.is_on():

--- a/switchbot/devices/smart_thermostat_radiator.py
+++ b/switchbot/devices/smart_thermostat_radiator.py
@@ -41,6 +41,7 @@ MODE_TEMP_RANGE = {
 }
 
 DEFAULT_TEMP_RANGE = (5.0, 35.0)
+HYSTERESIS_IDLE_THRESHOLD = 0.5
 
 
 class SwitchbotSmartThermostatRadiator(
@@ -200,7 +201,7 @@ class SwitchbotSmartThermostatRadiator(
         if (
             current_temp is not None
             and target_temp is not None
-            and current_temp >= (target_temp + 0.5)
+            and current_temp >= (target_temp + HYSTERESIS_IDLE_THRESHOLD)
         ):
             return ClimateAction.IDLE
 

--- a/tests/test_smart_thermostat_radiator.py
+++ b/tests/test_smart_thermostat_radiator.py
@@ -223,10 +223,17 @@ def test_default_model_classvar():
 
 @pytest.mark.asyncio
 async def test_thermostat_idle_action() -> None:
-    """Test that the TRV reports IDLE when current temp exceeds target temp + hysteresis."""
-    device = create_device_for_command_testing(
-        SMART_THERMOSTAT_RADIATOR_INFO,
-        {"target_temperature": 20.0, "temperature": 28.0},
+    """Test TRV action transitions exactly at the 0.5°C hysteresis boundary."""
+    # Case 1: Room temperature is exactly at target + 0.5 -> Should be IDLE
+    device_at_boundary = create_device_for_command_testing(
+        SMART_THERMOSTAT_RADIATOR_INFO, 
+        {"target_temperature": 20.0, "temperature": 20.5}
     )
+    assert device_at_boundary.hvac_action == ClimateAction.IDLE
 
-    assert device.hvac_action == ClimateAction.IDLE
+    # Case 2: Room is warm but within the 0.5 chattering band -> Should still be HEATING
+    device_in_band = create_device_for_command_testing(
+        SMART_THERMOSTAT_RADIATOR_INFO, 
+        {"target_temperature": 20.0, "temperature": 20.4}
+    )
+    assert device_in_band.hvac_action == ClimateAction.HEATING

--- a/tests/test_smart_thermostat_radiator.py
+++ b/tests/test_smart_thermostat_radiator.py
@@ -226,14 +226,14 @@ async def test_thermostat_idle_action() -> None:
     """Test TRV action transitions exactly at the 0.5°C hysteresis boundary."""
     # Case 1: Room temperature is exactly at target + 0.5 -> Should be IDLE
     device_at_boundary = create_device_for_command_testing(
-        SMART_THERMOSTAT_RADIATOR_INFO, 
-        {"target_temperature": 20.0, "temperature": 20.5}
+        SMART_THERMOSTAT_RADIATOR_INFO,
+        {"target_temperature": 20.0, "temperature": 20.5},
     )
     assert device_at_boundary.hvac_action == ClimateAction.IDLE
 
     # Case 2: Room is warm but within the 0.5 chattering band -> Should still be HEATING
     device_in_band = create_device_for_command_testing(
-        SMART_THERMOSTAT_RADIATOR_INFO, 
-        {"target_temperature": 20.0, "temperature": 20.4}
+        SMART_THERMOSTAT_RADIATOR_INFO,
+        {"target_temperature": 20.0, "temperature": 20.4},
     )
     assert device_in_band.hvac_action == ClimateAction.HEATING

--- a/tests/test_smart_thermostat_radiator.py
+++ b/tests/test_smart_thermostat_radiator.py
@@ -219,3 +219,14 @@ def test_default_model_classvar():
         ble_device, "ff", "ffffffffffffffffffffffffffffffff"
     )
     assert device._model == SMART_THERMOSTAT_RADIATOR_INFO.modelName
+
+
+@pytest.mark.asyncio
+async def test_thermostat_idle_action() -> None:
+    """Test that the TRV reports IDLE when current temp exceeds target temp + hysteresis."""
+    device = create_device_for_command_testing(
+        SMART_THERMOSTAT_RADIATOR_INFO,
+        {"target_temperature": 20.0, "temperature": 28.0},
+    )
+
+    assert device.hvac_action == ClimateAction.IDLE


### PR DESCRIPTION
Currently, the SwitchBot TRV unconditionally reports `ClimateAction.HEATING` as long as the device is turned on, even if the room temperature has met or exceeded the target temperature. This causes smart home dashboards (like Home Assistant) to permanently show the device as actively heating.

This PR adds a 0.5°C threshold check to infer an `IDLE` state when the room is warm, matching standard thermostat behavior.