### PR TITLE
chore: enable additional ruff lint rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,8 @@ target-version = "py311"
 line-length = 88
 
 [tool.ruff.lint]
+preview = true
+explicit-preview-rules = true # opt in ONLY explicitly-listed preview rules
 ignore = [
     "S101", # use of assert
     "D203", # 1 blank line required before class docstring
@@ -34,15 +36,30 @@ ignore = [
 ]
 select = [
     "ASYNC", # async rules
+    "A",   # flake8-builtins
     "B",   # flake8-bugbear
+    "BLE", # flake8-blind-except
     "D",   # flake8-docstrings
     "C4",  # flake8-comprehensions
+    "C90", # mccabe complexity
+    "DTZ", # flake8-datetimez
+    "ERA", # eradicate
+    "EXE", # flake8-executable
     "S",   # flake8-bandit
     "F",   # pyflake
+    "FA",  # flake8-future-annotations
+    "FIX", # flake8-fixme
+    "FURB", # refurb
+    "FURB118", # reimplemented-operator (preview) - unneeded lambdas
     "E",   # pycodestyle
     "W",   # pycodestyle
     "UP",  # pyupgrade
     "I",   # isort
+    "ICN", # flake8-import-conventions
+    "INP", # flake8-no-pep420
+    "ISC", # flake8-implicit-str-concat
+    "LOG", # flake8-logging
+    "Q",   # flake8-quotes
     "RUF", # ruff specific
     "FLY", # flynt
     "G", # flake8-logging-format   ,
@@ -60,8 +77,10 @@ select = [
     "SLOT", # flake8-slots
     "T100", # Trace found: {name} used
     "T20", # flake8-print
+    "TD",  # flake8-todos
     "TID", # Tidy imports
     "TRY", # tryceratops
+    "YTT", # flake8-2020
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/switchbot/discovery.py
+++ b/switchbot/discovery.py
@@ -53,7 +53,7 @@ class GetSwitchbotDevices:
         devices = None
         devices = bleak.BleakScanner(
             detection_callback=self.detection_callback,
-            # TODO: Find new UUIDs to filter on. For example, see
+            # Could filter on service UUIDs once new ones are identified; see
             # https://github.com/OpenWonderLabs/SwitchBotAPI-BLE/blob/4ad138bb09f0fbbfa41b152ca327a78c1d0b6ba9/devicetypes/meter.md
             adapter=self._interface,
         )
@@ -65,9 +65,7 @@ class GetSwitchbotDevices:
 
         if devices is None:
             if retry < 1:
-                _LOGGER.error(
-                    "Scanning for Switchbot devices failed. Stop trying", exc_info=True
-                )
+                _LOGGER.error("Scanning for Switchbot devices failed. Stop trying")
                 return self._adv_data
 
             _LOGGER.warning(

--- a/switchbot/utils.py
+++ b/switchbot/utils.py
@@ -17,7 +17,7 @@ def format_mac_upper(mac: str) -> str:
         to_test = to_test.replace(".", "")
 
     if len(to_test) == 12:
-        # no : included
+        # bare 12-char hex, insert colons
         return ":".join(to_test.upper()[i : i + 2] for i in range(0, 12, 2))
 
     # Not sure how formatted, return original


### PR DESCRIPTION
Enables a batch of additional ruff rule families; most are pure ratchets with zero current violations, so no code changes were needed for those. It also turns on FURB118 (reimplemented-operator), which flags lambdas that just wrap an operator or attribute access; that was the one unneeded-lambda check we were missing, and it needs preview plus explicit-preview-rules to opt in just that rule. Three small fixups ride along for the LOG, TD/FIX, and ERA rules, dropping a stray exc_info outside an except handler, rewording a TODO comment, and clarifying a comment that eradicate misread as dead code.