### PR TITLE
fix: allow API users to think about vertical oscillation "angle" in degrees.

### DIFF
--- a/switchbot/const/fan.py
+++ b/switchbot/const/fan.py
@@ -59,8 +59,11 @@ class VerticalOscillationAngle(Enum):
 
     ANGLE_30 = 30
     ANGLE_60 = 60
-    ANGLE_90 = 90
+    ANGLE_90 = 95
     ANGLE_MAX = 95
 
-    def __init__(self, value: int) -> None:
-        self._value_ = 95 if value == 90 else value
+    @classmethod
+    def _missing_(cls, value: int) -> VerticalOscillationAngle | None:
+        if value == 90:
+            return cls.ANGLE_90
+        return None

--- a/switchbot/const/fan.py
+++ b/switchbot/const/fan.py
@@ -60,7 +60,6 @@ class VerticalOscillationAngle(Enum):
     ANGLE_30 = 30
     ANGLE_60 = 60
     ANGLE_90 = 95
-    ANGLE_MAX = 95
 
     @classmethod
     def _missing_(cls, value: int) -> VerticalOscillationAngle | None:

--- a/switchbot/const/fan.py
+++ b/switchbot/const/fan.py
@@ -59,4 +59,8 @@ class VerticalOscillationAngle(Enum):
 
     ANGLE_30 = 30
     ANGLE_60 = 60
-    ANGLE_90 = 95
+    ANGLE_90 = 90
+    ANGLE_MAX = 95
+
+    def __init__(self, value: int) -> None:
+        self._value_ = 95 if value == 90 else value

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -545,9 +545,9 @@ async def test_standing_fan_set_vertical_oscillation_angle_int(byte_value):
 async def test_standing_fan_set_vertical_oscillation_angle_90():
     """Raw-int callers may also use 90 degrees, which maps to byte 0x5F (95)."""
     standing_fan = create_standing_fan_for_testing()
-    byte_value = 95
     await standing_fan.set_vertical_oscillation_angle(90)
     cmd = standing_fan._send_command.call_args[0][0]
+    byte_value = VerticalOscillationAngle.ANGLE_90.value
     assert cmd == f"{fan.COMMAND_SET_OSCILLATION_PARAMS}FFFF{byte_value:02X}FF"
 
 

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -540,6 +540,14 @@ async def test_standing_fan_set_vertical_oscillation_angle_int(byte_value):
     cmd = standing_fan._send_command.call_args[0][0]
     assert cmd == f"{fan.COMMAND_SET_OSCILLATION_PARAMS}FFFF{byte_value:02X}FF"
 
+@pytest.mark.asyncio
+async def test_standing_fan_set_vertical_oscillation_angle_90():
+    """Raw-int callers may also use 90 degrees, which maps to byte 0x5F (95)."""
+    standing_fan = create_standing_fan_for_testing()
+    byte_value = 95
+    await standing_fan.set_vertical_oscillation_angle(90)
+    cmd = standing_fan._send_command.call_args[0][0]
+    assert cmd == f"{fan.COMMAND_SET_OSCILLATION_PARAMS}FFFF{byte_value:02X}FF"
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("angle", [0, 45, 120, -1])

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -540,6 +540,7 @@ async def test_standing_fan_set_vertical_oscillation_angle_int(byte_value):
     cmd = standing_fan._send_command.call_args[0][0]
     assert cmd == f"{fan.COMMAND_SET_OSCILLATION_PARAMS}FFFF{byte_value:02X}FF"
 
+
 @pytest.mark.asyncio
 async def test_standing_fan_set_vertical_oscillation_angle_90():
     """Raw-int callers may also use 90 degrees, which maps to byte 0x5F (95)."""
@@ -548,6 +549,7 @@ async def test_standing_fan_set_vertical_oscillation_angle_90():
     await standing_fan.set_vertical_oscillation_angle(90)
     cmd = standing_fan._send_command.call_args[0][0]
     assert cmd == f"{fan.COMMAND_SET_OSCILLATION_PARAMS}FFFF{byte_value:02X}FF"
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("angle", [0, 45, 120, -1])


### PR DESCRIPTION
A little tickery provides enough abstraction that API users can think in degrees or with byte-value awareness. This makes integrating with common input controls more natural.