### PR TITLE
feat: support the sync-datetime protocol on the plain Meter Pro

### DIFF
--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -61,7 +61,7 @@ from .devices.light_strip import (
     SwitchbotStripLight3,
 )
 from .devices.lock import SwitchbotLock
-from .devices.meter_pro import SwitchbotMeterProCO2
+from .devices.meter_pro import SwitchbotMeterPro, SwitchbotMeterProCO2
 from .devices.plug import SwitchbotPlugMini
 from .devices.relay_switch import (
     SwitchbotGarageDoorOpener,
@@ -116,6 +116,7 @@ __all__ = [
     "SwitchbotKeypadVision",
     "SwitchbotLightStrip",
     "SwitchbotLock",
+    "SwitchbotMeterPro",
     "SwitchbotMeterProCO2",
     "SwitchbotModel",
     "SwitchbotModel",

--- a/switchbot/devices/meter_pro.py
+++ b/switchbot/devices/meter_pro.py
@@ -12,8 +12,8 @@ COMMAND_SET_DEVICE_DATETIME = "57000503"
 COMMAND_SET_DISPLAY_FORMAT = "570f680505"
 
 
-class SwitchbotMeterProCO2(SwitchbotDevice):
-    """API to control Switchbot Meter Pro CO2."""
+class SwitchbotMeterPro(SwitchbotDevice):
+    """API to control Switchbot Meter Pro (and Meter Pro CO2, which shares the same datetime protocol)."""
 
     async def get_time_offset(self) -> int:
         """
@@ -170,3 +170,7 @@ class SwitchbotMeterProCO2(SwitchbotDevice):
                 f"{self.name}: Unexpected response len for {op_name}, wanted at least {min_length} (result={result.hex() if result else 'None'} rssi={self.rssi})"
             )
         return result
+
+
+class SwitchbotMeterProCO2(SwitchbotMeterPro):
+    """API to control Switchbot Meter Pro CO2."""

--- a/tests/test_meter_pro.py
+++ b/tests/test_meter_pro.py
@@ -4,14 +4,18 @@ import pytest
 from bleak.backends.device import BLEDevice
 
 from switchbot import SwitchbotOperationError
-from switchbot.devices.meter_pro import MAX_TIME_OFFSET, SwitchbotMeterProCO2
+from switchbot.devices.meter_pro import (
+    MAX_TIME_OFFSET,
+    SwitchbotMeterPro,
+    SwitchbotMeterProCO2,
+)
 
 
-def create_device():
+def create_device(cls=SwitchbotMeterProCO2):
     ble_device = BLEDevice(
         address="aa:bb:cc:dd:ee:ff", name="any", details={"rssi": -80}
     )
-    device = SwitchbotMeterProCO2(ble_device)
+    device = cls(ble_device)
     device._send_command = AsyncMock()
     return device
 
@@ -247,3 +251,20 @@ async def test_set_time_display_format_failure():
 
     with pytest.raises(SwitchbotOperationError):
         await device.set_time_display_format(is_12h_mode=True)
+
+
+@pytest.mark.asyncio
+async def test_meter_pro_shares_datetime_protocol_with_co2_variant():
+    """The plain Meter Pro (no CO2 sensor) uses the same BLE commands as the CO2 variant."""
+    device = create_device(SwitchbotMeterPro)
+    device._send_command.return_value = bytes.fromhex("01e40294230007e90c1e083701")
+
+    result = await device.get_datetime()
+    device._send_command.assert_called_with("570f6901")
+    assert result["year"] == 2025
+
+    device._send_command.return_value = bytes.fromhex("01")
+    await device.set_datetime(1709251200)
+    device._send_command.assert_called_with(
+        "57000503" + "0c" + "65e11a80".zfill(16) + "00"
+    )


### PR DESCRIPTION
Fixes #542

## Proposed change

The Meter Pro CO2 already supports syncing its date/time over BLE
(`SwitchbotMeterProCO2.set_datetime()` / `get_datetime()` /
`set_time_offset()` / `set_time_display_format()`), added in a previous PR.

The plain **Meter Pro (without CO2)** is a separate device
(`SwitchbotModel.METER_PRO`), and the library had no equivalent support for
it — the [home-assistant/core issue](https://github.com/home-assistant/core/issues/167438)
asking for this was closed as stale.

I verified against real hardware (a Meter Pro, non-CO2) that it understands
the *exact same* BLE commands as the CO2 variant: `get_datetime()` and
`set_datetime()` both succeed and behave identically. As a control, I also
verified that a plain Meter Plus (`SwitchbotModel.METER`) rejects the same
command with an error response code, confirming the datetime protocol is
specific to the Meter Pro family and not something the older Meter/Meter
Plus firmware understands.

This PR renames `SwitchbotMeterProCO2` to `SwitchbotMeterPro` (the shared
base class for the whole family) and keeps `SwitchbotMeterProCO2` as an
empty subclass, so existing code doing `isinstance(x, SwitchbotMeterProCO2)`
keeps working unchanged.

A follow-up PR to home-assistant/core wires this up to the same
"Sync date and time" button already used for the CO2 variant.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes #542
- This PR is related to https://github.com/home-assistant/core/issues/167438
- Contribution by Sven Kirmess (skirmess), assisted by Claude Code

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally (verified against real Meter Pro + Meter Plus hardware).
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.
